### PR TITLE
Fix bug when reading of staxml from a directory

### DIFF
--- a/src/S0B_to_ASDF.py
+++ b/src/S0B_to_ASDF.py
@@ -201,12 +201,11 @@ for ick in range(rank,splits,size):
         t1=time.time()
         inv1   = noise_module.stats2inv(source[0].stats,prepro_para,locs=locs)      
         tr = noise_module.preprocess_raw(source,inv1,prepro_para,date_info)
-        if np.all(tr[0].data==0):continue
+        # jump if no good data left
+        if not len(tr): continue
+        if np.all(tr[0].data==0): continue
         t2 = time.time()
         if flag:print('pre-processing takes %6.2fs'%(t2-t1))
-
-        # jump if no good data left
-        if not len(tr):continue
 
         # ready for output
         ff=os.path.join(RAWDATA,all_chunk[ick]+'T'+all_chunk[ick+1]+'.h5')


### PR DESCRIPTION
Hi, 

hope it's okay to suggest code changes with a pull request. There is a bug when using S0B and choosing to read StationXML response from a directory. In stats2inv(), since glob.glob() returns a list, L292 and 293 in noise_module fail. In preprocess_raw() I added a check on if the response is empty (which previously happened when stats2inv failed to read the response from staxml). Also moved the check on empty data in S0B (lines 208-210) earlier because it tr is empty, there will be an indexing error raised at Line 204.

Thanks for making NoisePy available to the community! It's very useful for my work.

Genevieve