### PR TITLE
CLI entry point and download step testing during CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,4 +29,4 @@ jobs:
         pip install "."
     - name: Test Download
       working-directory: ./src
-      run: python noisepy.py download --start 2019_02_01_00_00_00 --end 2019_02_01_02_00_00 --stations ARV --channels BHZ --inc_hours 1 --path .
+      run: python noisepy.py download --start 2019_02_01_00_00_00 --end 2019_02_01_02_00_00 --stations ARV --inc_hours 1 --path .

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,3 +27,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install "."
+    - name: Test Download
+      working-directory: ./src
+      run: python noisepy.py download --start 2019_02_01_00_00_00 --end 2019_02_01_02_00_00 --stations ARV --channels BHZ --inc_hours 1 --rootpath .

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,4 +29,4 @@ jobs:
         pip install "."
     - name: Test Download
       working-directory: ./src
-      run: python noisepy.py download --start 2019_02_01_00_00_00 --end 2019_02_01_02_00_00 --stations ARV --channels BHZ --inc_hours 1 --rootpath .
+      run: python noisepy.py download --start 2019_02_01_00_00_00 --end 2019_02_01_02_00_00 --stations ARV --channels BHZ --inc_hours 1 --path .

--- a/src/S0A_download_ASDF_MPI.py
+++ b/src/S0A_download_ASDF_MPI.py
@@ -61,11 +61,11 @@ freqmax   = 2                                                   # note this cann
 
 # targeted region/station information: only needed when down_list is False
 lamin,lamax,lomin,lomax = 32.9,35.9,-120.7,-118.5               # regional box: min lat, min lon, max lat, max lon (-114.0)
-chan_list = ["BHE","BHN","BHZ"]                                             # channel if down_list=false (format like "HN?" not work here)
+chan_list = ["BHZ"]                                             # channel if down_list=false (format like "HN?" not work here)
 net_list  = ["CI"]                                              # network list 
-sta_list  = ["*"]                                               # station (using a station list is way either compared to specifying stations one by one)
-start_date = ["2016_07_01_0_0_0"]                               # start date of download
-end_date   = ["2016_07_02_0_0_0"]                               # end date of download
+sta_list  = ["SDD"]                                               # station (using a station list is way either compared to specifying stations one by one)
+start_date = ["2019_02_03_0_0_0"]                               # start date of download
+end_date   = ["2019_02_04_0_0_0"]                               # end date of download
 inc_hours  = 24                                                 # length of data for each request (in hour)
 ncomp      = len(chan_list)
 

--- a/src/S0A_download_ASDF_MPI.py
+++ b/src/S0A_download_ASDF_MPI.py
@@ -1,5 +1,6 @@
 import sys
 import time
+from typing import List
 import obspy
 import pyasdf
 import os, glob
@@ -45,9 +46,7 @@ Enjoy the NoisePy journey!
 tt0=time.time()
 
 # paths and filenames
-rootpath  = os.path.join(os.path.expanduser('~'), 'Documents/SCAL')         # root path for this data processing
-direc  = os.path.join(rootpath,'RAW_DATA')                      # where to store the downloaded data
-dlist  = os.path.join(direc,'station.txt')                      # CSV file for station location info
+default_rootpath  = os.path.join(os.path.expanduser('~'), 'Documents/SCAL')         # root path for this data processing
 
 # download parameters
 client    = Client('SCEDC')                                     # client/data center. see https://docs.obspy.org/packages/obspy.clients.fdsn.html for a list
@@ -55,19 +54,17 @@ down_list = False                                               # download stati
 flag      = False                                               # print progress when running the script; recommend to use it at the begining
 samp_freq = 20                                                  # targeted sampling rate at X samples per seconds 
 rm_resp   = 'no'                                                # select 'no' to not remove response and use 'inv','spectrum','RESP', or 'polozeros' to remove response
-respdir   = os.path.join(rootpath,'resp')                       # directory where resp files are located (required if rm_resp is neither 'no' nor 'inv')
 freqmin   = 0.05                                                # pre filtering frequency bandwidth
 freqmax   = 2                                                   # note this cannot exceed Nquist freq                         
 
 # targeted region/station information: only needed when down_list is False
 lamin,lamax,lomin,lomax = 32.9,35.9,-120.7,-118.5               # regional box: min lat, min lon, max lat, max lon (-114.0)
-chan_list = ["BHZ"]                                             # channel if down_list=false (format like "HN?" not work here)
 net_list  = ["CI"]                                              # network list 
-sta_list  = ["SDD"]                                               # station (using a station list is way either compared to specifying stations one by one)
-start_date = ["2019_02_03_0_0_0"]                               # start date of download
-end_date   = ["2019_02_04_0_0_0"]                               # end date of download
-inc_hours  = 24                                                 # length of data for each request (in hour)
-ncomp      = len(chan_list)
+default_inc_hours  = 24                                                 # length of data for each request (in hour)
+default_chan_list = ["BHE","BHN","BHZ"]                                             # channel if down_list=false (format like "HN?" not work here)
+default_sta_list  = ["*"]                                               # station (using a station list is way either compared to specifying stations one by one)
+default_start_date = ["2016_07_01_0_0_0"]                               # start date of download
+default_end_date   = ["2016_07_02_0_0_0"]                               # end date of download
 
 # get rough estimate of memory needs to ensure it now below up in S1
 cc_len    = 1800                                                # basic unit of data length for fft (s)
@@ -77,229 +74,244 @@ MAX_MEM   = 5.0                                                 # maximum memory
 ##################################################
 # we expect no parameters need to be changed below
 
-# time tags
-starttime = obspy.UTCDateTime(start_date[0])       
-endtime   = obspy.UTCDateTime(end_date[0])
-if flag:
-    print('station.list selected [%s] for data from %s to %s with %sh interval'%(down_list,starttime,endtime,inc_hours))
 
-# assemble parameters used for pre-processing
-prepro_para = {'rm_resp':rm_resp,
-               'respdir':respdir,
-               'freqmin':freqmin,
-               'freqmax':freqmax,
-               'samp_freq':samp_freq,
-               'start_date':start_date,
-               'end_date':end_date,
-               'inc_hours':inc_hours,
-               'cc_len':cc_len,
-               'step':step,
-               'MAX_MEM':MAX_MEM,
-               'lamin':lamin,
-               'lamax':lamax,
-               'lomin':lomin,
-               'lomax':lomax,
-               'ncomp':ncomp}
-metadata = os.path.join(direc,'download_info.txt') 
+def download(rootpath: str, chan_list: List[str], sta_list: List[str], start_date: List[str], end_date: List[str], inc_hours: int):
+    direc  = os.path.join(rootpath,'RAW_DATA')                      # where to store the downloaded data
+    dlist  = os.path.join(direc,'station.txt')                      # CSV file for station location info
+    respdir   = os.path.join(rootpath,'resp')                       # directory where resp files are located (required if rm_resp is neither 'no' nor 'inv')
+    # time tags
+    starttime = obspy.UTCDateTime(start_date[0])       
+    endtime   = obspy.UTCDateTime(end_date[0])
+    if flag:
+        print('station.list selected [%s] for data from %s to %s with %sh interval'%(down_list,starttime,endtime,inc_hours))
+    print(f"""Download 
+        From: {starttime}
+        To: {endtime}
+        Stations: {sta_list}
+        Channels: {chan_list}
+        """)
+    ncomp      = len(chan_list)
+    # assemble parameters used for pre-processing
+    prepro_para = {'rm_resp':rm_resp,
+                'respdir':respdir,
+                'freqmin':freqmin,
+                'freqmax':freqmax,
+                'samp_freq':samp_freq,
+                'start_date':str(starttime),
+                'end_date':str(endtime),
+                'inc_hours':inc_hours,
+                'cc_len':cc_len,
+                'step':step,
+                'MAX_MEM':MAX_MEM,
+                'lamin':lamin,
+                'lamax':lamax,
+                'lomin':lomin,
+                'lomax':lomax,
+                'ncomp':ncomp}
+    metadata = os.path.join(direc,'download_info.txt') 
 
-# prepare station info (existing station list vs. fetching from client)
-if down_list:
-    if not os.path.isfile(dlist):
-        raise IOError('file %s not exist! double check!' % dlist)
+    # prepare station info (existing station list vs. fetching from client)
+    if down_list:
+        if not os.path.isfile(dlist):
+            raise IOError('file %s not exist! double check!' % dlist)
 
-    # read station info from list
-    locs = pd.read_csv(dlist)                   
-    nsta = len(locs)
-    chan = list(locs.iloc[:]['channel'])
-    net  = list(locs.iloc[:]['network'])
-    sta  = list(locs.iloc[:]['station'])
-    lat  = list(locs.iloc[:]['latitude'])
-    lon  = list(locs.iloc[:]['longitude'])
+        # read station info from list
+        locs = pd.read_csv(dlist)               
+        nsta = len(locs)
+        chan = list(locs.iloc[:]['channel'])
+        net  = list(locs.iloc[:]['network'])
+        sta  = list(locs.iloc[:]['station'])
+        lat  = list(locs.iloc[:]['latitude'])
+        lon  = list(locs.iloc[:]['longitude'])
 
-    # location info: useful for some occasion
-    try:
-        location = list(locs.iloc[:]['location'])
-    except Exception as e:
-        location = ['*']*nsta
+        # location info: useful for some occasion
+        try:
+            location = list(locs.iloc[:]['location'])
+        except Exception as e:
+            location = ['*']*nsta
 
-else:
-
-    # calculate the total number of channels to download
-    sta=[];net=[];chan=[];location=[];lon=[];lat=[];elev=[]
-    nsta=0
-
-    # loop through specified network, station and channel lists
-    for inet in net_list:
-        for ista in sta_list:
-            for ichan in chan_list:
-                # gather station info
-                try:
-                    inv = client.get_stations(network=inet,
-                                              station=ista,
-                                              channel=ichan,
-                                              location='*',
-                                              starttime=starttime,
-                                              endtime=endtime,
-                                              minlatitude=lamin,
-                                              maxlatitude=lamax, 
-                                              minlongitude=lomin, 
-                                              maxlongitude=lomax,
-                                              level='response')
-                except Exception as e:
-                    print('Abort at L126 in S0A due to '+str(e))
-                    sys.exit()
-
-                for K in inv:
-                    for tsta in K:
-                        sta.append(tsta.code)
-                        net.append(K.code)
-                        chan.append(ichan)
-                        lon.append(tsta.longitude)
-                        lat.append(tsta.latitude)
-                        elev.append(tsta.elevation)
-                        # sometimes one station has many locations and here we only get the first location
-                        if tsta[0].location_code:
-                            location.append(tsta[0].location_code)
-                        else: location.append('*')
-                        nsta+=1
-    prepro_para['nsta'] = nsta
-
-# rough estimation on memory needs (assume float32 dtype)
-nsec_chunk = inc_hours/24*86400
-nseg_chunk = int(np.floor((nsec_chunk-cc_len)/step))+1
-npts_chunk = int(nseg_chunk*cc_len*samp_freq)
-memory_size = nsta*npts_chunk*4/1024**3
-if memory_size > MAX_MEM:
-    raise ValueError('Require %5.3fG memory but only %5.3fG provided)! Reduce inc_hours to avoid this issue!' % (memory_size,MAX_MEM))
-
-
-########################################################
-#################DOWNLOAD SECTION#######################
-########################################################
-
-#--------MPI---------
-comm = MPI.COMM_WORLD
-rank = comm.Get_rank()
-size = comm.Get_size()
-
-if rank==0:
-    if not os.path.isdir(rootpath):
-        os.mkdir(rootpath)
-    if not os.path.isdir(direc):
-        os.mkdir(direc)
-    
-    # output station list
-    if not down_list:     
-        dict = {'network':net,
-                'station':sta,
-                'channel':chan,
-                'latitude':lat,
-                'longitude':lon,
-                'elevation':elev}
-        locs = pd.DataFrame(dict)        
-        locs.to_csv(os.path.join(direc,'station.txt'),index=False)
-    
-    # save parameters for future reference
-    fout = open(metadata,'w')
-    fout.write(str(prepro_para));fout.close()
-
-    # get MPI variables ready 
-    all_chunk = noise_module.get_event_list(start_date[0],end_date[0],inc_hours)
-    if len(all_chunk)<1:
-        raise ValueError('Abort! no data chunk between %s and %s' % (start_date[0],end_date[0]))
-    splits = len(all_chunk)-1
-else:
-    splits,all_chunk = [None for _ in range(2)]
-
-# broadcast the variables
-splits = comm.bcast(splits,root=0)
-all_chunk  = comm.bcast(all_chunk,root=0)
-extra = splits % size
-
-tp = 0
-# MPI: loop through each time chunk 
-for ick in range(rank,splits,size):
-
-    s1=obspy.UTCDateTime(all_chunk[ick])
-    s2=obspy.UTCDateTime(all_chunk[ick+1]) 
-    date_info = {'starttime':s1,'endtime':s2} 
-    
-    # keep a track of the channels already exists
-    num_records = np.zeros(nsta,dtype=np.int16)
-
-    # filename of the ASDF file
-    ff=os.path.join(direc,all_chunk[ick]+'T'+all_chunk[ick+1]+'.h5')
-    if not os.path.isfile(ff):
-        with pyasdf.ASDFDataSet(ff,mpi=False,compression="gzip-3",mode='w') as ds:
-            pass
     else:
-        with pyasdf.ASDFDataSet(ff,mpi=False,mode='r') as rds:
-            alist = rds.waveforms.list()
+
+        # calculate the total number of channels to download
+        sta=[];net=[];chan=[];location=[];lon=[];lat=[];elev=[]
+        nsta=0
+
+        # loop through specified network, station and channel lists
+        for inet in net_list:
+            for ista in sta_list:
+                for ichan in chan_list:
+                    # gather station info
+                    try:
+                        inv = client.get_stations(network=inet,
+                                                station=ista,
+                                                channel=ichan,
+                                                location='*',
+                                                starttime=starttime,
+                                                endtime=endtime,
+                                                minlatitude=lamin,
+                                                maxlatitude=lamax, 
+                                                minlongitude=lomin, 
+                                                maxlongitude=lomax,
+                                                level='response')
+                    except Exception as e:
+                        print('Abort at L126 in S0A due to '+str(e))
+                        sys.exit()
+
+                    for K in inv:
+                        for tsta in K:
+                            sta.append(tsta.code)
+                            net.append(K.code)
+                            chan.append(ichan)
+                            lon.append(tsta.longitude)
+                            lat.append(tsta.latitude)
+                            elev.append(tsta.elevation)
+                            # sometimes one station has many locations and here we only get the first location
+                            if tsta[0].location_code:
+                                location.append(tsta[0].location_code)
+                            else: location.append('*')
+                            nsta+=1
+        prepro_para['nsta'] = nsta
+
+    # rough estimation on memory needs (assume float32 dtype)
+    nsec_chunk = inc_hours/24*86400
+    nseg_chunk = int(np.floor((nsec_chunk-cc_len)/step))+1
+    npts_chunk = int(nseg_chunk*cc_len*samp_freq)
+    memory_size = nsta*npts_chunk*4/1024**3
+    if memory_size > MAX_MEM:
+        raise ValueError('Require %5.3fG memory but only %5.3fG provided)! Reduce inc_hours to avoid this issue!' % (memory_size,MAX_MEM))
+
+
+    ########################################################
+    #################DOWNLOAD SECTION#######################
+    ########################################################
+
+    #--------MPI---------
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    size = comm.Get_size()
+
+    if rank==0:
+        if not os.path.isdir(rootpath):
+            os.mkdir(rootpath)
+        if not os.path.isdir(direc):
+            os.mkdir(direc)
+        
+        # output station list
+        if not down_list:     
+            dict = {'network':net,
+                    'station':sta,
+                    'channel':chan,
+                    'latitude':lat,
+                    'longitude':lon,
+                    'elevation':elev}
+            locs = pd.DataFrame(dict)        
+            locs.to_csv(os.path.join(direc,'station.txt'),index=False)
+        
+        # save parameters for future reference
+        fout = open(metadata,'w')
+        fout.write(str(prepro_para));fout.close()
+
+        # get MPI variables ready 
+        all_chunk = noise_module.get_event_list(start_date[0],end_date[0],inc_hours)
+        if len(all_chunk)<1:
+            raise ValueError('Abort! no data chunk between %s and %s' % (start_date[0],end_date[0]))
+        splits = len(all_chunk)-1
+    else:
+        splits,all_chunk = [None for _ in range(2)]
+
+    # broadcast the variables
+    splits = comm.bcast(splits,root=0)
+    all_chunk  = comm.bcast(all_chunk,root=0)
+    extra = splits % size
+
+    tp = 0
+    # MPI: loop through each time chunk 
+    for ick in range(rank,splits,size):
+
+        s1=obspy.UTCDateTime(all_chunk[ick])
+        s2=obspy.UTCDateTime(all_chunk[ick+1]) 
+        date_info = {'starttime':s1,'endtime':s2} 
+        
+        # keep a track of the channels already exists
+        num_records = np.zeros(nsta,dtype=np.int16)
+
+        # filename of the ASDF file
+        ff=os.path.join(direc,all_chunk[ick]+'T'+all_chunk[ick+1]+'.h5')
+        if not os.path.isfile(ff):
+            with pyasdf.ASDFDataSet(ff,mpi=False,compression="gzip-3",mode='w') as ds:
+                pass
+        else:
+            with pyasdf.ASDFDataSet(ff,mpi=False,mode='r') as rds:
+                alist = rds.waveforms.list()
+                for ista in range(nsta):
+                    tname = net[ista]+'.'+sta[ista]
+                    if tname in alist:
+                        num_records[ista] = len(rds.waveforms[tname].get_waveform_tags())
+
+        # appending when file exists
+        with pyasdf.ASDFDataSet(ff,mpi=False,compression="gzip-3",mode='a') as ds:
+
+            # loop through each channel
             for ista in range(nsta):
-                tname = net[ista]+'.'+sta[ista]
-                if tname in alist:
-                    num_records[ista] = len(rds.waveforms[tname].get_waveform_tags())
 
-    # appending when file exists
-    with pyasdf.ASDFDataSet(ff,mpi=False,compression="gzip-3",mode='a') as ds:
+                # continue when there are alreay data for sta A at day X
+                if num_records[ista] == ncomp:
+                    continue
 
-        # loop through each channel
-        for ista in range(nsta):
+                # get inventory for specific station
+                try:
+                    sta_inv = client.get_stations(network=net[ista],
+                                                station=sta[ista],
+                                                location=location[ista],
+                                                starttime=s1,
+                                                endtime=s2,
+                                                level="response")
+                except Exception as e:
+                    print(e);continue
 
-            # continue when there are alreay data for sta A at day X
-            if num_records[ista] == ncomp:
-                continue
+                # add the inventory for all components + all time of this tation         
+                try:
+                    ds.add_stationxml(sta_inv) 
+                except Exception: 
+                    pass   
 
-            # get inventory for specific station
-            try:
-                sta_inv = client.get_stations(network=net[ista],
-                                              station=sta[ista],
-                                              location=location[ista],
-                                              starttime=s1,
-                                              endtime=s2,
-                                              level="response")
-            except Exception as e:
-                print(e);continue
+                try:
+                    # get data
+                    t0=time.time()
+                    tr = client.get_waveforms(network=net[ista],
+                                            station=sta[ista],
+                                            channel=chan[ista],
+                                            location=location[ista],
+                                            starttime=s1,
+                                            endtime=s2)
+                    t1=time.time()
+                except Exception as e:
+                    print(e,'for',sta[ista]);continue
+                    
+                # preprocess to clean data  
+                print(sta[ista])
+                tr = noise_module.preprocess_raw(tr,sta_inv,prepro_para,date_info)
+                t2 = time.time()
+                tp += t2-t1
 
-            # add the inventory for all components + all time of this tation         
-            try:
-                ds.add_stationxml(sta_inv) 
-            except Exception: 
-                pass   
+                if len(tr):
+                    if location[ista] == '*':
+                        tlocation = str('00')
+                    else:
+                        tlocation = location[ista]
+                    new_tags = '{0:s}_{1:s}'.format(chan[ista].lower(),tlocation.lower())
+                    ds.add_waveforms(tr,tag=new_tags)
 
-            try:
-                # get data
-                t0=time.time()
-                tr = client.get_waveforms(network=net[ista],
-                                          station=sta[ista],
-                                          channel=chan[ista],
-                                          location=location[ista],
-                                          starttime=s1,
-                                          endtime=s2)
-                t1=time.time()
-            except Exception as e:
-                print(e,'for',sta[ista]);continue
-                
-            # preprocess to clean data  
-            print(sta[ista])
-            tr = noise_module.preprocess_raw(tr,sta_inv,prepro_para,date_info)
-            t2 = time.time()
-            tp += t2-t1
+                #if flag:
+                print(ds,new_tags);print('downloading data %6.2f s; pre-process %6.2f s' % ((t1-t0),(t2-t1)))
 
-            if len(tr):
-                if location[ista] == '*':
-                    tlocation = str('00')
-                else:
-                    tlocation = location[ista]
-                new_tags = '{0:s}_{1:s}'.format(chan[ista].lower(),tlocation.lower())
-                ds.add_waveforms(tr,tag=new_tags)
+    tt1=time.time()
+    print('downloading step takes %6.2f s with %6.2f for preprocess' %(tt1-tt0, tp))
 
-            #if flag:
-            print(ds,new_tags);print('downloading data %6.2f s; pre-process %6.2f s' % ((t1-t0),(t2-t1)))
+    comm.barrier()
+    if rank == 0:
+        sys.exit()
 
-tt1=time.time()
-print('downloading step takes %6.2f s with %6.2f for preprocess' %(tt1-tt0, tp))
-
-comm.barrier()
-if rank == 0:
-    sys.exit()
+# Keeping this for backward compatibility, but the preferred entry point is: noisepy.py download
+if __name__ == "__main__":
+    download(default_rootpath, default_chan_list, default_sta_list, default_start_date, default_end_date, default_inc_hours)

--- a/src/noisepy.py
+++ b/src/noisepy.py
@@ -1,0 +1,40 @@
+import argparse
+import obspy
+import os
+import typing
+from enum import Enum
+from S0A_download_ASDF_MPI import download
+
+# Utility running the different steps from the command line. Defines the arguments for each step
+
+DATE_FORMAT = '%%Y_%%m_%%d_%%H_%%M_%%S'
+
+class Step(Enum):
+    DOWNLOAD = 1
+    CROSS_CORRELATE = 2
+    STACK = 3
+
+def valid_date(d: str) -> str:
+    _ = obspy.UTCDateTime(d)
+    return d    
+
+def main(args: typing.Any):
+    if args.step == Step.DOWNLOAD:
+        download(args.path, args.channels, args.stations, [args.start], [args.end], args.inc_hours)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='step', required=True)
+    
+    # Download arguments
+    down_parser = subparsers.add_parser(Step.DOWNLOAD.name.lower())
+    down_parser.add_argument("--path", type=str, default=os.path.join(os.path.expanduser('~'), 'Documents/SCAL'), help="Directory for downloading files")
+    down_parser.add_argument("--start", type=valid_date, required=True, help="Start date in the format: "+DATE_FORMAT)
+    down_parser.add_argument("--end",   type=valid_date, required=True, help="End date in the format: "+DATE_FORMAT)
+    down_parser.add_argument("--stations", type=lambda s: s.split(","), help="Comma separated list of stations or '*' (default)", default="*")
+    down_parser.add_argument("--channels", type=lambda s: s.split(","), help="Comma separated list of channels", default="BHE,BHN,BHZ")
+    down_parser.add_argument("--inc_hours", type=int, default=24, help="Time increment size (hrs)")
+    args = parser.parse_args()
+    args.step = Step[args.step.upper()]
+    main(args)
+


### PR DESCRIPTION
The goal of this PR is to enable CI testing of the download step (other steps to follow). The main change is the addition of a command line interface (CLI) and a small refactoring of ```S0A_download_ASDF_MPI.py``` to allow the CLI to call it. With this change, it's easier to execute the steps by passing arguments on the command line instead of changing the code. E.g.:
```
usage: noisepy.py download [-h] [--path PATH] --start START --end END
                           [--stations STATIONS] [--channels CHANNELS]
                           [--inc_hours INC_HOURS]

optional arguments:
  -h, --help            show this help message and exit
  --path PATH           Directory for downloading files
  --start START         Start date in the format: %Y_%m_%d_%H_%M_%S
  --end END             End date in the format: %Y_%m_%d_%H_%M_%S
  --stations STATIONS   Comma separated list of stations or '*' (default)
  --channels CHANNELS   Comma separated list of channels
  --inc_hours INC_HOURS
                        Time increment size (hrs)
```

Currently I only made configurable the parameters needed to test the download, but others can be added too.
