### PR TITLE
Update tutorial to use requirements.txt and noisepy.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ Jiang, C. and Denolle, M. "NoisePy: a new high-performance python tool for seism
 # Installation
 The nature of NoisePy being composed of python scripts allows flexible package installation, which is essentially to build dependent libraries the scripts and related functions live upon. We recommend using [conda](https://docs.conda.io/en/latest/) or [pip](https://pypi.org/project/pip/) to install the library due to their convenience. Below are command lines we have tested to create a python environment to run NoisePy. Note that the test is performed on `macOS Mojave (10.14.5)`, so it could be slightly different for other OS. 
 
-## Pre-requisites
-
-An MPI installation is required. E.g. for macOS using (brew)[https://brew.sh/] :
-```sh
-brew install open-mpi
-```
 
 ### Note the order of the command lines below matters ###
 
@@ -36,9 +30,16 @@ brew install open-mpi
 ```bash
 conda create -n noisepy python=3.8 pip
 conda activate noisepy
+conda install -c conda-forge openmpi
 pip install -r requirements.txt
 ```
+
 # With virtual environment:
+An MPI installation is required. E.g. for macOS using [brew](https://brew.sh/) :
+```sh
+brew install open-mpi
+```
+
 ```bash
 python -m venv noisepy
 source noisepy/bin/activate

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Jiang, C. and Denolle, M. "NoisePy: a new high-performance python tool for seism
 * adding a jupter notebook for generating response spectrum for a nodal array (to be done)
 
 # Installation
-The nature of NoisePy being composed of python scripts allows flexible package installation, which is essentially to build dependented libraries the scripts and related functions live upon. We recommend to use [conda](https://docs.conda.io/en/latest/) or [pip](https://pypi.org/project/pip/) to install the library due to their convenience. Below are command lines we have tested that would create a python environment to run NoisePy. Note that the test is performed on `macOS Mojave (10.14.5)`, so it could be slightly different for other OS. 
+The nature of NoisePy being composed of python scripts allows flexible package installation, which is essentially to build dependent libraries the scripts and related functions live upon. We recommend using [conda](https://docs.conda.io/en/latest/) or [pip](https://pypi.org/project/pip/) to install the library due to their convenience. Below are command lines we have tested to create a python environment to run NoisePy. Note that the test is performed on `macOS Mojave (10.14.5)`, so it could be slightly different for other OS. 
 
 ## Pre-requisites
 
@@ -45,7 +45,6 @@ source noisepy/bin/activate
 pip install -r requirements.txt
 ```
 To run the code on a single core, open the terminal and activate the noisepy environment before run following command. To run on institutional clusters, see installation notes for individual packages on the module list of the cluster. Examples of installation on Frontera are below.
-
 
 # Functionality
 * download continous noise data based on obspy's core functions of [get_station](https://docs.obspy.org/packages/autogen/obspy.clients.fdsn.client.Client.get_stations.html) and [get_waveforms](https://docs.obspy.org/packages/autogen/obspy.clients.fdsn.client.Client.get_waveforms.html)

--- a/README.md
+++ b/README.md
@@ -21,33 +21,31 @@ Jiang, C. and Denolle, M. "NoisePy: a new high-performance python tool for seism
 * adding a jupter notebook for generating response spectrum for a nodal array (to be done)
 
 # Installation
-The nature of NoisePy being composed of python scripts allows flexiable package installation, which is essentially to build dependented libraries the scripts and related functions live upon. We recommand to use [conda](https://docs.conda.io/en/latest/) and [pip](https://pypi.org/project/pip/) to install the library due to their convinence. Below are command lines we have tested that would create a python environment to run NoisePy. Note that the test is performed on `macOS Mojave (10.14.5)`, so it could be slightly different for other OS. 
+The nature of NoisePy being composed of python scripts allows flexible package installation, which is essentially to build dependented libraries the scripts and related functions live upon. We recommend to use [conda](https://docs.conda.io/en/latest/) or [pip](https://pypi.org/project/pip/) to install the library due to their convenience. Below are command lines we have tested that would create a python environment to run NoisePy. Note that the test is performed on `macOS Mojave (10.14.5)`, so it could be slightly different for other OS. 
+
+## Pre-requisites
+
+An MPI installation is required. E.g. for macOS using (brew)[https://brew.sh/] :
+```sh
+brew install open-mpi
+```
 
 ### Note the order of the command lines below matters ###
 
 # With Conda:
-```python
-conda create -n noisepy -c conda-forge python=3.7 numpy=1.16.2 numba pandas pycwt jupyter mpi4py=3.0.1 obspy=1.1 pyasdf
+```bash
+conda create -n noisepy python=3.8 pip
 conda activate noisepy
-git clone https://github.com/mdenolle/NoisePy.git
+pip install -r requirements.txt
 ```
 # With virtual environment:
-```python
+```bash
 python -m venv noisepy
 source noisepy/bin/activate
-pip install wheel h5py numpy numba pandas pycwt jupyter mpi4py pyasdf
-git clone https://github.com/mdenolle/NoisePy.git
+pip install -r requirements.txt
 ```
 To run the code on a single core, open the terminal and activate the noisepy environment before run following command. To run on institutional clusters, see installation notes for individual packages on the module list of the cluster. Examples of installation on Frontera are below.
 
-# Installing on institutional clusters:
-Here is an example on how to install it on Frontera. hyp5 is already installed under the phdf5 default module.
-```python
-python -m venv noisepy
-source noisepy/bin/activate
-pip install wheel  numpy numba pandas pycwt jupyter mpi4py pyasdf
-git clone https://github.com/mdenolle/NoisePy.git
-```
 
 # Functionality
 * download continous noise data based on obspy's core functions of [get_station](https://docs.obspy.org/packages/autogen/obspy.clients.fdsn.client.Client.get_stations.html) and [get_waveforms](https://docs.obspy.org/packages/autogen/obspy.clients.fdsn.client.Client.get_waveforms.html)
@@ -58,18 +56,20 @@ git clone https://github.com/mdenolle/NoisePy.git
 
 # Short tutorial
 
-### 0A. Downloading seismic noise data by using `S0A_download_ASDF_MPI.py`
+### 0A. Downloading seismic noise data (`src/S0A_download_ASDF_MPI.py`)
 This script (located in the directory of `src`) and its existing parameters allows to download all available broadband CI stations `(BH?)` located in a certain region and operated during 1/Jul/2016-2/Jul/2016 through the SCEC data center. 
 
 In the script, short summary is provided for all input parameters that can be changed according to the user's needs. In the current form of the script, we set `inc_hours=24` to download day-long continous noise data as well as the meta info and store them into a single ASDF file. To increase the signal-to-noise (SNR) of the final cross-correlation functions (see Seats et al.,2012 for more details), we break the day-long sequence into smaller segments, each of `cc_len` (s) long with some overlapping defined by `step`. You may wanto to set `flag` to be `True` if intermediate outputs/operational time is preferred during the downloading process. 
 
-```python
-python S0A_download_ASDF_MPI.py
+```bash
+cd src
+python noisepy.py download
 ```  
+The data to be downloaded can be customized via command line arguments. See `python noisepy.py download --help` for details.
 
 If you want to use multiple cores (e.g, 4), run the script with the following command using [mpi4py](https://mpi4py.readthedocs.io/en/stable/). 
-```python
-mpirun -n 4 python S0A_download_ASDF_MPI.py
+```bash
+mpirun -n 4 python noisepy.py download 
 ```
 
 The outputted files from S0A include ASDF files containing daily-long (24h) continous noise data, a parameter file recording all used parameters in the script of S0A and a CSV file of all station information (more details on reading the ASDF files with downloaded data can be found in docs/src/ASDF.md). The continous waveforms data stored in the ASDF file can be displayed using the plotting modules named as `plotting_modules` in the directory of `src` as shown below.

--- a/src/S0A_download_ASDF_MPI.py
+++ b/src/S0A_download_ASDF_MPI.py
@@ -3,12 +3,11 @@ import time
 from typing import List
 import obspy
 import pyasdf
-import os, glob
+import os 
 import numpy as np
 import pandas as pd
 import noise_module
 from mpi4py import MPI
-from obspy import UTCDateTime
 from obspy.clients.fdsn import Client
 
 if not sys.warnoptions:
@@ -45,9 +44,6 @@ Enjoy the NoisePy journey!
 #########################################################
 tt0=time.time()
 
-# paths and filenames
-default_rootpath  = os.path.join(os.path.expanduser('~'), 'Documents/SCAL')         # root path for this data processing
-
 # download parameters
 client    = Client('SCEDC')                                     # client/data center. see https://docs.obspy.org/packages/obspy.clients.fdsn.html for a list
 down_list = False                                               # download stations from a pre-compiled list or not
@@ -60,11 +56,6 @@ freqmax   = 2                                                   # note this cann
 # targeted region/station information: only needed when down_list is False
 lamin,lamax,lomin,lomax = 32.9,35.9,-120.7,-118.5               # regional box: min lat, min lon, max lat, max lon (-114.0)
 net_list  = ["CI"]                                              # network list 
-default_inc_hours  = 24                                                 # length of data for each request (in hour)
-default_chan_list = ["BHE","BHN","BHZ"]                                             # channel if down_list=false (format like "HN?" not work here)
-default_sta_list  = ["*"]                                               # station (using a station list is way either compared to specifying stations one by one)
-default_start_date = ["2016_07_01_0_0_0"]                               # start date of download
-default_end_date   = ["2016_07_02_0_0_0"]                               # end date of download
 
 # get rough estimate of memory needs to ensure it now below up in S1
 cc_len    = 1800                                                # basic unit of data length for fft (s)
@@ -312,6 +303,6 @@ def download(rootpath: str, chan_list: List[str], sta_list: List[str], start_dat
     if rank == 0:
         sys.exit()
 
-# Keeping this for backward compatibility, but the preferred entry point is: noisepy.py download
+# Point people to new entry point:
 if __name__ == "__main__":
-    download(default_rootpath, default_chan_list, default_sta_list, default_start_date, default_end_date, default_inc_hours)
+    print("Please see:\n\npython noisepy.py download --help\n")

--- a/src/noisepy.py
+++ b/src/noisepy.py
@@ -8,6 +8,8 @@ from S0A_download_ASDF_MPI import download
 # Utility running the different steps from the command line. Defines the arguments for each step
 
 DATE_FORMAT = '%%Y_%%m_%%d_%%H_%%M_%%S'
+default_start_date = "2016_07_01_0_0_0"                               # start date of download
+default_end_date   = "2016_07_02_0_0_0"                               # end date of download
 
 class Step(Enum):
     DOWNLOAD = 1
@@ -27,11 +29,11 @@ if __name__ == "__main__":
     subparsers = parser.add_subparsers(dest='step', required=True)
     
     # Download arguments
-    down_parser = subparsers.add_parser(Step.DOWNLOAD.name.lower())
+    down_parser = subparsers.add_parser(Step.DOWNLOAD.name.lower(), formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     down_parser.add_argument("--path", type=str, default=os.path.join(os.path.expanduser('~'), 'Documents/SCAL'), help="Directory for downloading files")
-    down_parser.add_argument("--start", type=valid_date, required=True, help="Start date in the format: "+DATE_FORMAT)
-    down_parser.add_argument("--end",   type=valid_date, required=True, help="End date in the format: "+DATE_FORMAT)
-    down_parser.add_argument("--stations", type=lambda s: s.split(","), help="Comma separated list of stations or '*' (default)", default="*")
+    down_parser.add_argument("--start", type=valid_date, required=True, help="Start date in the format: "+DATE_FORMAT, default=default_start_date)
+    down_parser.add_argument("--end",   type=valid_date, required=True, help="End date in the format: "+DATE_FORMAT, default=default_end_date)
+    down_parser.add_argument("--stations", type=lambda s: s.split(","), help="Comma separated list of stations or '*' for all", default="*")
     down_parser.add_argument("--channels", type=lambda s: s.split(","), help="Comma separated list of channels", default="BHE,BHN,BHZ")
     down_parser.add_argument("--inc_hours", type=int, default=24, help="Time increment size (hrs)")
     args = parser.parse_args()


### PR DESCRIPTION
- Remove `S0A_download_ASDF_MPI.py` as an entry point
- Update README to use the new entry point and to use `requirements.txt` for installation
- Moved defaults to the CLI and display them in the help text:
```
usage: noisepy.py download [-h] [--path PATH] --start START --end END
                           [--stations STATIONS] [--channels CHANNELS]
                           [--inc_hours INC_HOURS]

optional arguments:
  -h, --help            show this help message and exit
  --path PATH           Directory for downloading files (default:
                        /Users/carlosg/Documents/SCAL)
  --start START         Start date in the format: %Y_%m_%d_%H_%M_%S (default:
                        2016_07_01_0_0_0)
  --end END             End date in the format: %Y_%m_%d_%H_%M_%S (default:
                        2016_07_02_0_0_0)
  --stations STATIONS   Comma separated list of stations or '*' for all
                        (default: *)
  --channels CHANNELS   Comma separated list of channels (default:
                        BHE,BHN,BHZ)
  --inc_hours INC_HOURS
                        Time increment size (hrs) (default: 24)

```