### PR TITLE
Fix: rFFT and FFT inconsistency leads to broadcast error #50

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,10 @@ jobs:
       run: python noisepy.py download --start 2019_02_01_00_00_00 --end 2019_02_01_02_00_00 --stations ARV,BAK --inc_hours 1 --path .
     - name: Test Cross-Correlation (S1)
       working-directory: ./src
-      run: python noisepy.py cross_correlate --path .
+      run: |
+        python noisepy.py cross_correlate --path . --freq_norm rma
+        rm -rf CCF
+        python noisepy.py cross_correlate --path . --freq_norm no
     - name: Test Stacking (S2)
       working-directory: ./src
       run: |

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: cross_correlate",
+      "type": "python",
+      "preLaunchTask": "Remove CCF",
+      "request": "launch",
+      "program": "${workspaceFolder}/src/noisepy.py",
+      "args": [
+        "cross_correlate",
+        "--freq_norm",
+        "rma"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": true
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,10 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Remove CCF",
+      "type": "shell",
+      "command": "rm -rf ${userHome}/Documents/SCAL/CCF"
+    }
+  ]
+}

--- a/src/S1_fft_cc_MPI.py
+++ b/src/S1_fft_cc_MPI.py
@@ -47,7 +47,6 @@ rootpath  = os.path.join(os.path.expanduser('~'), 'Documents/SCAL')         # ro
 
 # some control parameters
 input_fmt   = 'h5'                                                          # string: 'h5', 'sac','mseed'
-freq_norm   = 'rma'                                                         # 'no' for no whitening, or 'rma' for running-mean average, 'phase_only' for sign-bit normalization in freq domain.
 time_norm   = 'no'                                                          # 'no' for no normalization, or 'rma', 'one_bit' for normalization in time domain
 cc_method   = 'xcorr'                                                       # 'xcorr' for pure cross correlation, 'deconv' for deconvolution; FOR "COHERENCY" PLEASE set freq_norm to "rma", time_norm to "no" and cc_method to "xcorr"
 flag        = True                                                          # print intermediate variables and computing time for debugging purpose
@@ -78,7 +77,22 @@ max_over_std = 10                                                           # th
 # maximum memory allowed per core in GB
 MAX_MEM = 4.0
 
-def cross_correlate(rootpath: str):
+def resize_fft(fft: np.array, n: int, nfft2: int) -> np.array:
+    # check the size to see if this is an rFFT (half) and resize accordingly
+    if fft.size // 2 == n*nfft2:
+        fft = fft[0:(int(fft.size/2))]
+    return fft.reshape(n, nfft2)
+
+
+def cross_correlate(rootpath: str, freq_norm: str):
+    """
+        Perform the cross-correlation analysis
+
+            Parameters:
+                    rootpath (str): Directory to load data from
+                    freq_norm (int): 'no' for no whitening, or 'rma' for running-mean average, 'phase_only' for sign-bit normalization in freq domain.
+    """
+
     CCFDIR    = os.path.join(rootpath,'CCF')                                    # dir to store CC data
     DATADIR   = os.path.join(rootpath,'RAW_DATA')                               # dir where noise data is located
     locations = os.path.join(DATADIR,'station.txt')                             # station info including network,station,channel,latitude,longitude,elevation: only needed when input_fmt is not h5 for asdf
@@ -325,8 +339,8 @@ def cross_correlate(rootpath: str):
             t0=time.time()
             #-----------get the smoothed source spectrum for decon later----------
             sfft1 = noise_module.smooth_source_spect(fc_para,fft1)
-            sfft1_halved= sfft1[0:(int(sfft1.size/2))]
-            sfft1 = sfft1_halved.reshape(N,Nfft2)
+            sfft1 = resize_fft(sfft1, N, Nfft2)
+
             t1=time.time()
             if flag:
                 print('smoothing source takes %6.4fs' % (t1-t0))
@@ -362,8 +376,7 @@ def cross_correlate(rootpath: str):
                 if not fft_flag[iiR]: continue
 
                 fft2 = fft_array[iiR]
-                fft2_halved= fft2[0:(int(fft2.size/2))]
-                sfft2 = fft2_halved.reshape(N,Nfft2)
+                sfft2 = resize_fft(fft2, N,Nfft2)
                 receiver_std = fft_std[iiR]
 
                 #---------- check the existence of earthquakes ----------

--- a/src/noisepy.py
+++ b/src/noisepy.py
@@ -27,7 +27,7 @@ def main(args: typing.Any):
     if args.step == Step.DOWNLOAD:
         download(args.path, args.channels, args.stations, [args.start], [args.end], args.inc_hours)
     if args.step == Step.CROSS_CORRELATE:
-        cross_correlate(args.path)
+        cross_correlate(args.path, args.freq_norm)
     if args.step == Step.STACK:
         stack(args.path, args.method)
 
@@ -46,6 +46,7 @@ if __name__ == "__main__":
     # Cross_correlate arguments
     cc_parser = subparsers.add_parser(Step.CROSS_CORRELATE.name.lower(), formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     cc_parser.add_argument("--path", type=str, default=os.path.join(os.path.expanduser('~'), default_data_path), help="Directory to look for input files")
+    cc_parser.add_argument("--freq_norm", choices=["rma", "no"], default="rma")
     # Stack arguments
     stack_parser = subparsers.add_parser(Step.STACK.name.lower(), formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     stack_parser.add_argument("--path", type=str, default=os.path.join(os.path.expanduser('~'), default_data_path), help="Directory to look for input files")


### PR DESCRIPTION
- Conditionally resize the matrices depending on the rFFT/FFT scenario
- Add `freq_norm` as a parameter and command line argument 
- Test both `freq_norm` modes (`no`, `rma`)