### PR TITLE
Add Dockerfile for building container for noisepy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM --platform=$BUILDPLATFORM ubuntu:22.04
+
+RUN apt-get update && \
+    apt-get install -y libopenmpi-dev && \
+    apt-get install -y python3 && \
+    apt-get install -y python3-pip && \
+    pip3 install --upgrade pip
+
+# Copy and install requirements first so this layer doesn't change when copy the local files below
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+ADD . .
+WORKDIR /src
+ENTRYPOINT ["python3", "noisepy.py"]
+CMD ["--help"]


### PR DESCRIPTION
Allows for running noisepy via container. E.g:

```
$ docker run noisepy
usage: noisepy.py [-h] {download,cross_correlate,stack} ...

positional arguments:
  {download,cross_correlate,stack}

options:
  -h, --help            show this help message and exit
```
By mapping a volume (**-v**) it can be used to download/process data in the local file system. E.g.
```
mkdir ./tmp
docker run -v ./tmp:/tmp noisepy download \
--start 2019_02_01_00_00_00 \
--end 2019_02_01_01_00_00 \
--stations ARV,BAK \
--inc_hours 1 \
--path /tmp
```