### PR TITLE
Remove uses of sys.exit()

### DIFF
--- a/src/S0A_download_ASDF_MPI.py
+++ b/src/S0A_download_ASDF_MPI.py
@@ -185,8 +185,9 @@ def download(
                             level="response",
                         )
                     except Exception as e:
-                        print("Abort at L126 in S0A due to " + str(e))
-                        sys.exit()
+                        raise Exception(
+                            "Abort at S0A client.get_stations due to " + str(e)
+                        )
 
                     for K in inv:
                         for tsta in K:
@@ -361,8 +362,6 @@ def download(
     print("downloading step takes %6.2f s with %6.2f for preprocess" % (tt1 - tt0, tp))
 
     comm.barrier()
-    if rank == 0:
-        sys.exit()
 
 
 # Point people to new entry point:

--- a/src/S0B_to_ASDF.py
+++ b/src/S0B_to_ASDF.py
@@ -274,5 +274,3 @@ tt1 = time.time()
 print("step0B takes " + str(tt1 - tt0) + " s")
 
 comm.barrier()
-if rank == 0:
-    sys.exit()

--- a/src/S1_fft_cc_MPI.py
+++ b/src/S1_fft_cc_MPI.py
@@ -525,10 +525,6 @@ def cross_correlate(rootpath: str, freq_norm: str):
     print("it takes %6.2fs to process step 1 in total" % (tt1 - tt0))
     comm.barrier()
 
-    # merge all path_array and output
-    if rank == 0:
-        sys.exit()
-
 
 # Point people to new entry point:
 if __name__ == "__main__":

--- a/src/S2_stacking.py
+++ b/src/S2_stacking.py
@@ -457,10 +457,6 @@ def stack(rootpath: str, stack_method: str):
     print("it takes %6.2fs to process step 2 in total" % (tt1 - tt0))
     comm.barrier()
 
-    # merge all path_array and output
-    if rank == 0:
-        sys.exit()
-
 
 # Point people to new entry point:
 if __name__ == "__main__":

--- a/src/plotting_modules.py
+++ b/src/plotting_modules.py
@@ -46,8 +46,7 @@ def plot_waveform(sfile, net, sta, freqmin, freqmax, savefig=False, sdir=None):
         ds = pyasdf.ASDFDataSet(sfile, mode="r")
         sta_list = ds.waveforms.list()
     except Exception:
-        print("exit! cannot open %s to read" % sfile)
-        sys.exit()
+        raise Exception("exit! cannot open %s to read" % sfile)
 
     # check whether station exists
     tsta = net + "." + sta
@@ -156,8 +155,7 @@ def plot_substack_cc(sfile, freqmin, freqmax, disp_lag=None, savefig=True, sdir=
         dt = ds.auxiliary_data[spairs[0]][path_lists[0]].parameters["dt"]
         maxlag = ds.auxiliary_data[spairs[0]][path_lists[0]].parameters["maxlag"]
     except Exception:
-        print("exit! cannot open %s to read" % sfile)
-        sys.exit()
+        raise Exception("exit! cannot open %s to read" % sfile)
 
     # only works for cross-correlation with substacks generated
     if not flag:
@@ -301,8 +299,7 @@ def plot_substack_cc_spect(
         dt = ds.auxiliary_data[spairs[0]][path_lists[0]].parameters["dt"]
         maxlag = ds.auxiliary_data[spairs[0]][path_lists[0]].parameters["maxlag"]
     except Exception:
-        print("exit! cannot open %s to read" % sfile)
-        sys.exit()
+        raise Exception("exit! cannot open %s to read" % sfile)
 
     # only works for cross-correlation with substacks generated
     if not flag:
@@ -453,8 +450,7 @@ def plot_substack_all(
         dist = ds.auxiliary_data[dtype_lists[0]][paths].parameters["dist"]
         maxlag = ds.auxiliary_data[dtype_lists[0]][paths].parameters["maxlag"]
     except Exception:
-        print("exit! cannot open %s to read" % sfile)
-        sys.exit()
+        raise Exception("exit! cannot open %s to read" % sfile)
 
     if len(dtype_lists) == 1:
         raise ValueError("Abort! seems no substacks have been done")
@@ -584,8 +580,7 @@ def plot_substack_all_spect(
         dist = ds.auxiliary_data[dtype_lists[0]][paths].parameters["dist"]
         maxlag = ds.auxiliary_data[dtype_lists[0]][paths].parameters["maxlag"]
     except Exception:
-        print("exit! cannot open %s to read" % sfile)
-        sys.exit()
+        raise Exception("exit! cannot open %s to read" % sfile)
 
     if len(dtype_lists) == 1:
         raise ValueError("Abort! seems no substacks have been done")
@@ -720,8 +715,7 @@ def plot_all_moveout(
         maxlag = ds.auxiliary_data[dtype][path].parameters["maxlag"]
         stack_method = dtype.split("0")[-1]
     except Exception:
-        print("exit! cannot open %s to read" % sfiles[0])
-        sys.exit()
+        raise Exception("exit! cannot open %s to read" % sfiles[0])
 
     # lags for display
     if not disp_lag:
@@ -850,8 +844,7 @@ def plot_all_moveout_1D_1comp(
         dt = ds.auxiliary_data[dtype][ccomp].parameters["dt"]
         maxlag = ds.auxiliary_data[dtype][ccomp].parameters["maxlag"]
     except Exception:
-        print("exit! cannot open %s to read" % sfiles[0])
-        sys.exit()
+        raise Exception("exit! cannot open %s to read" % sfiles[0])
 
     # lags for display
     if not disp_lag:
@@ -960,8 +953,7 @@ def plot_all_moveout_1D_9comp(
         dt = ds.auxiliary_data[dtype][ccomp[0]].parameters["dt"]
         maxlag = ds.auxiliary_data[dtype][ccomp[0]].parameters["maxlag"]
     except Exception:
-        print("exit! cannot open %s to read" % sfiles[0])
-        sys.exit()
+        raise Exception("exit! cannot open %s to read" % sfiles[0])
 
     # lags for display
     if not disp_lag:

--- a/test/mpi_download/S0_download_ASDF_MPI.py
+++ b/test/mpi_download/S0_download_ASDF_MPI.py
@@ -237,5 +237,3 @@ for ick in range(rank, splits + size - extra, size):
 tt1 = time.time()
 print("downloading step takes %6.2f s" % (tt1 - tt0))
 comm.barrier()
-if rank == 0:
-    sys.exit()

--- a/test/mpi_download/loop_for_mpi.py
+++ b/test/mpi_download/loop_for_mpi.py
@@ -28,10 +28,6 @@ def test1():
         tdata = data[ii]
         print("index %d rank %d and data %f" % (ii, rank, tdata))
 
-    comm.barrier()
-    if rank == 0:
-        sys.exit()
-
 
 def test2():
     # --------MPI---------
@@ -54,8 +50,6 @@ def test2():
         print("index %d rank %d and data %f" % (ii, rank, tdata))
 
     comm.barrier()
-    if rank == 0:
-        sys.exit()
 
 
 def test3():
@@ -79,10 +73,6 @@ def test3():
         if ii < splits:
             tdata = data[ii]
             print("index %d rank %d and data %f" % (ii, rank, tdata))
-
-    comm.barrier()
-    if rank == 0:
-        sys.exit()
 
 
 def main():

--- a/test/test.py
+++ b/test/test.py
@@ -180,8 +180,7 @@ else:
                         level="response",
                     )
                 except Exception as e:
-                    print("Abort at L126 in S0A due to " + str(e))
-                    sys.exit()
+                    raise Exception("Abort at L126 in S0A due to " + str(e))
 
                 for K in inv:
                     for tsta in K:
@@ -1174,7 +1173,3 @@ for ipair in range(rank, splits, size):
 tt1 = time.time()
 print("it takes %6.2fs to process step 2 in total" % (tt1 - tt0))
 comm.barrier()
-
-# merge all path_array and output
-if rank == 0:
-    sys.exit()


### PR DESCRIPTION
Explicit calls to sys.exit() make the software hard to use as a library (vs standalone scripts). They are also unnecessary in most cases. The calls fall into two categories:

- `sys.exit()` calls for rank 0 nodes in mpi. These are just removed since the process will naturally exit anyway.
- `sys.exit()` calls after hitting an error. In this case it's better to raise an exception. This allows the caller to catch/handle it if needed and if not caught the process will exit with an error code anyway.