### PR TITLE
ASDFCCStore: Remove use of tmp file

### DIFF
--- a/src/noisepy/seis/asdfstore.py
+++ b/src/noisepy/seis/asdfstore.py
@@ -11,7 +11,7 @@ import pyasdf
 from datetimerange import DateTimeRange
 
 from . import noise_module
-from .constants import DATE_FORMAT, DONE_MARKER
+from .constants import DATE_FORMAT, DONE_PATH, PROGRESS_DATATYPE
 from .datatypes import Channel, ChannelData, ChannelType, ConfigParameters, Station
 from .stores import CrossCorrelationDataStore, RawDataStore
 
@@ -72,11 +72,11 @@ class ASDFCCStore(CrossCorrelationDataStore):
     def contains(
         self, timespan: DateTimeRange, src_chan: Channel, rec_chan: Channel, parameters: ConfigParameters
     ) -> bool:
-        key = get_channel_pair_key(src_chan, rec_chan)
-        exists = self._tmp_contains(timespan, key)
-        if exists:
-            logger.info(f"Cross-correlation {key} already exists")
-        return exists
+        data_type = self._get_data_type(src_chan, rec_chan)
+        contains = self._contains(timespan, data_type)
+        if contains:
+            logger.info(f"Cross-correlation {data_type} already exists")
+        return contains
 
     def save_parameters(self, parameters: ConfigParameters):
         fc_metadata = os.path.join(self.directory, "fft_cc_data.txt")
@@ -95,49 +95,50 @@ class ASDFCCStore(CrossCorrelationDataStore):
         cc_params: Dict[str, Any],
         corr: np.ndarray,
     ):
-        filename = f"{os.path.join(self.directory, self._get_filename(timespan))}.h5"
-        with pyasdf.ASDFDataSet(filename, mpi=False) as ccf_ds:
-            # source-receiver pair
-            data_type = f"{src_chan.station}_{rec_chan.station}"
-            path = f"{src_chan.type}_{rec_chan.type}"
-            data = np.zeros(corr.shape, dtype=corr.dtype)
-            data[:] = corr[:]
-            ccf_ds.add_auxiliary_data(data=data, data_type=data_type, path=path, parameters=cc_params)
-
-        # record the progress
-        self._append_tmp(timespan, get_channel_pair_key(src_chan, rec_chan))
+        # source-receiver pair
+        path = f"{src_chan.type}_{rec_chan.type}"
+        data_type = self._get_data_type(src_chan, rec_chan)
+        data = np.zeros(corr.shape, dtype=corr.dtype)
+        data[:] = corr[:]
+        self._add_aux_data(timespan, cc_params, data_type, path, data)
 
     def is_done(self, timespan: DateTimeRange):
-        done = self._tmp_contains(timespan, DONE_MARKER)
+        done = self._contains(timespan, PROGRESS_DATATYPE, DONE_PATH)
         if done:
             logger.info(f"Timespan {timespan} already computed")
         return done
 
     def mark_done(self, timespan: DateTimeRange):
-        self._append_tmp(timespan, DONE_MARKER)
+        self._add_aux_data(timespan, {}, PROGRESS_DATATYPE, DONE_PATH, np.zeros(0))
 
     def read(self, chan1: Channel, chan2: Channel, start: datetime, end: datetime) -> np.ndarray:
         pass
 
-    def _get_filename(self, timespan: DateTimeRange) -> str:
-        return f"{timespan.start_datetime.strftime(DATE_FORMAT)}T{timespan.end_datetime.strftime(DATE_FORMAT)}"
-
-    def _get_tmp_filename(self, timespan: DateTimeRange) -> str:
-        base_filename = os.path.join(self.directory, self._get_filename(timespan))
-        return f"{base_filename}.tmp"
-
-    def _append_tmp(self, timespan: DateTimeRange, line: str):
-        tmp_filename = self._get_tmp_filename(timespan)
-        with open(tmp_filename, "a") as ftmp:
-            ftmp.write(f"{line}\n")
-
-    def _tmp_contains(self, timespan: DateTimeRange, key: str):
-        tmp_filename = self._get_tmp_filename(timespan)
-        if not os.path.isfile(tmp_filename):
+    def _contains(self, timespan: DateTimeRange, data_type: str, path: str = None):
+        filename = self._get_filename(timespan)
+        if not os.path.isfile(filename):
             return False
-        with open(tmp_filename, "r") as ftmp:
-            lines = set(ftmp.read().splitlines())
-            return key in lines
+
+        with pyasdf.ASDFDataSet(filename, mpi=False, mode="r") as ccf_ds:
+            # source-receiver pair
+            exists = data_type in ccf_ds.auxiliary_data
+            if path is not None and exists:
+                return path in ccf_ds.auxiliary_data[data_type]
+            return exists
+
+    def _add_aux_data(self, timespan: DateTimeRange, params: Dict, data_type: str, path: str, data: np.ndarray):
+        filename = self._get_filename(timespan)
+        with pyasdf.ASDFDataSet(filename, mpi=False) as ccf_ds:
+            ccf_ds.add_auxiliary_data(data=data, data_type=data_type, path=path, parameters=params)
+
+    def _get_data_type(self, src_chan, rec_chan):
+        return f"{src_chan.station}_{rec_chan.station}"
+
+    def _get_filename(self, timespan: DateTimeRange) -> str:
+        return os.path.join(
+            self.directory,
+            f"{timespan.start_datetime.strftime(DATE_FORMAT)}T{timespan.end_datetime.strftime(DATE_FORMAT)}.h5",
+        )
 
 
 def get_channel_pair_key(src_chan: Channel, rec_chan: Channel) -> str:

--- a/src/noisepy/seis/constants.py
+++ b/src/noisepy/seis/constants.py
@@ -1,4 +1,5 @@
 STATION_FILE = "station.txt"
 DATE_FORMAT_HELP = "%%Y_%%m_%%d_%%H_%%M_%%S"
 DATE_FORMAT = "%Y_%m_%d_%H_%M_%S"
-DONE_MARKER = "done"
+DONE_PATH = "done"
+PROGRESS_DATATYPE = "Progress"

--- a/tests/test_asdfstore.py
+++ b/tests/test_asdfstore.py
@@ -1,8 +1,12 @@
-from datetime import datetime
+from datetime import datetime, timedelta
+from pathlib import Path
 
+import numpy as np
 import pytest
+from datetimerange import DateTimeRange
 
-from noisepy.seis.asdfstore import ASDFRawDataStore
+from noisepy.seis.asdfstore import ASDFCCStore, ASDFRawDataStore
+from noisepy.seis.datatypes import Channel, ConfigParameters, Station
 
 
 @pytest.fixture
@@ -10,6 +14,13 @@ def store():
     import os
 
     return ASDFRawDataStore(os.path.join(os.path.dirname(__file__), "./data"))
+
+
+# Use the built in tmp_path fixture: https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html
+# to create a CC store
+@pytest.fixture
+def ccstore(tmp_path: Path) -> ASDFCCStore:
+    return ASDFCCStore(str(tmp_path))
 
 
 def test_get_timespans(store: ASDFRawDataStore):
@@ -34,3 +45,41 @@ def test_get_data(store: ASDFRawDataStore):
     assert chdata.data.size == 72001
     assert chdata.sampling_rate == 20.0
     assert chdata.start_timestamp == ts.start_datetime.timestamp()
+
+
+def test_ccstore(ccstore: ASDFCCStore):
+    def make_1dts(dt: datetime):
+        return DateTimeRange(dt, dt + timedelta(days=1))
+
+    config = ConfigParameters()
+    data = np.zeros(0)
+    ts1 = make_1dts(datetime.now())
+    ts2 = make_1dts(ts1.end_datetime)
+    src = Channel("foo", Station("nw", "sta1", -1, -1, -1, ""))
+    rec = Channel("bar", Station("nw", "sta2", -1, -1, -1, ""))
+
+    # assert empty state
+    assert not ccstore.is_done(ts1)
+    assert not ccstore.is_done(ts2)
+    assert not ccstore.contains(ts1, src, rec, config)
+    assert not ccstore.contains(ts2, src, rec, config)
+
+    # add CC (src->rec) for ts1
+    ccstore.append(ts1, src, rec, config, {}, data)
+    # assert ts1 is there, but not ts2
+    assert ccstore.contains(ts1, src, rec, config)
+    assert not ccstore.contains(ts2, src, rec, config)
+    # also rec->src should not be there for ts1
+    assert not ccstore.contains(ts1, rec, src, config)
+    assert not ccstore.is_done(ts1)
+    # now mark ts1 done and assert it
+    ccstore.mark_done(ts1)
+    assert ccstore.is_done(ts1)
+    assert not ccstore.is_done(ts2)
+
+    # now add CC for ts2
+    ccstore.append(ts2, src, rec, config, {}, data)
+    assert ccstore.contains(ts2, src, rec, config)
+    assert not ccstore.is_done(ts2)
+    ccstore.mark_done(ts2)
+    assert ccstore.is_done(ts2)


### PR DESCRIPTION
This PR removes the use of a tmp file (text file) to track already completed computations. Instead, it checks the ASDF file itself in two places:

- Presence of specific station pairs, E.g. `CI.BAK_CI.ARV`
- Presence of a dummy aux data `Progress/done` to mark that all station pairs are complete. This is similar to what the "DONE" last line in the temp file did and prevents having to compute all FFTs even if all CCs are already done.

E.g.
<img width="343" alt="image" src="https://user-images.githubusercontent.com/10456546/234405168-91472faf-6168-4739-ab8d-500ac0ad22ea.png">
