### PR TITLE
SCEDC bug fixes, channel filtering

### DIFF
--- a/src/noisepy/seis/S1_fft_cc_MPI.py
+++ b/src/noisepy/seis/S1_fft_cc_MPI.py
@@ -62,8 +62,8 @@ def cross_correlate(
                 raw_store: Store to load data from
                 fft_params: Parameters for the FFT calculations
                 cc_store: Store for saving cross correlations
-                channel_filter: Function to decide whether a station should be used or not,
-                                if None, all stations are used
+                channel_filter: Function to decide whether a channel should be used or not,
+                                if None, all channels are used
 
     """
 

--- a/src/noisepy/seis/S1_fft_cc_MPI.py
+++ b/src/noisepy/seis/S1_fft_cc_MPI.py
@@ -2,13 +2,13 @@ import gc
 import logging
 import sys
 import time
-from typing import Tuple
+from typing import Callable, Tuple
 
 import numpy as np
 from mpi4py import MPI
 from scipy.fftpack.helper import next_fast_len
 
-from noisepy.seis.datatypes import ChannelData, ConfigParameters
+from noisepy.seis.datatypes import Channel, ChannelData, ConfigParameters
 
 from . import noise_module
 from .stores import CrossCorrelationDataStore, RawDataStore
@@ -49,7 +49,12 @@ NOTE:
 """
 
 
-def cross_correlate(raw_store: RawDataStore, fft_params: ConfigParameters, cc_store: CrossCorrelationDataStore):
+def cross_correlate(
+    raw_store: RawDataStore,
+    fft_params: ConfigParameters,
+    cc_store: CrossCorrelationDataStore,
+    channel_filter: Callable[[Channel], bool] = None,
+):
     """
     Perform the cross-correlation analysis
 
@@ -57,8 +62,13 @@ def cross_correlate(raw_store: RawDataStore, fft_params: ConfigParameters, cc_st
                 raw_store: Store to load data from
                 fft_params: Parameters for the FFT calculations
                 cc_store: Store for saving cross correlations
+                channel_filter: Function to decide whether a station should be used or not,
+                                if None, all stations are used
+
     """
 
+    if channel_filter is None:
+        channel_filter = lambda s: True  # noqa: E731
     #######################################
     # #########PROCESSING SECTION##########
     #######################################
@@ -94,6 +104,7 @@ def cross_correlate(raw_store: RawDataStore, fft_params: ConfigParameters, cc_st
 
         # ###########LOADING NOISE DATA AND DO FFT##################
         channels = raw_store.get_channels(ts)
+        channels = list(filter(channel_filter, channels))
         nchannels = len(channels)
         nseg_chunk = check_memory(fft_params, nchannels)
         nnfft = int(next_fast_len(int(fft_params.cc_len * fft_params.samp_freq)))  # samp_freq should be sampling_rate

--- a/src/noisepy/seis/channelcatalog.py
+++ b/src/noisepy/seis/channelcatalog.py
@@ -72,7 +72,8 @@ class FDSNChannelCatalog(ChannelCatalog):
         return f"{self.url_key}_{ts_str}"
 
     @cache
-    # pass the timestamp (DateTimeRange) as string to that it's cacheable
+    # pass the timestamp (DateTimeRange) as string so that the method is cacheable
+    # since DateTimeRange is not hasheable
     def _get_inventory(self, ts_str: str) -> obspy.Inventory:
         ts = DateTimeRange.from_range_text(ts_str)
         key = self._get_cache_key(ts_str)

--- a/src/noisepy/seis/channelcatalog.py
+++ b/src/noisepy/seis/channelcatalog.py
@@ -1,11 +1,13 @@
 import logging
 from abc import ABC, abstractmethod
+from functools import cache
 
 import diskcache as dc
 import obspy
 import pandas as pd
 from datetimerange import DateTimeRange
 from obspy import UTCDateTime
+from obspy.clients.fdsn import Client
 
 from .datatypes import Channel, Station
 
@@ -63,19 +65,22 @@ class FDSNChannelCatalog(ChannelCatalog):
         self.cache = dc.Cache(cache_dir)
 
     def get_full_channel(self, timespan: DateTimeRange, channel: Channel) -> Channel:
-        inv = self._get_inventory(timespan)
+        inv = self._get_inventory(str(timespan))
         return self.populate_from_inventory(inv, channel)
 
-    def _get_cache_key(self, timespan: DateTimeRange) -> str:
-        return f"{self.url_key}_{timespan}"
+    def _get_cache_key(self, ts_str: str) -> str:
+        return f"{self.url_key}_{ts_str}"
 
-    def _get_inventory(self, ts: DateTimeRange) -> obspy.Inventory:
-        key = FDSNChannelCatalog._get_cache_key(ts)
+    @cache
+    # pass the timestamp (DateTimeRange) as string to that it's cacheable
+    def _get_inventory(self, ts_str: str) -> obspy.Inventory:
+        ts = DateTimeRange.from_range_text(ts_str)
+        key = self._get_cache_key(ts_str)
         inventory = self.cache.get(key, None)
         if inventory is None:
             logging.info(f"Inventory not found in cache for key: '{key}'. Fetching from {self.url_key}.")
             bulk_station_request = [("*", "*", "*", "*", UTCDateTime(ts.start_datetime), UTCDateTime(ts.end_datetime))]
-            client = obspy.Client(self.url_key)
+            client = Client(self.url_key)
             inventory = client.get_stations_bulk(bulk_station_request, level="channel")
             self.cache[key] = inventory
         return inventory

--- a/src/noisepy/seis/datatypes.py
+++ b/src/noisepy/seis/datatypes.py
@@ -27,7 +27,10 @@ class ChannelType:
             self.name = self.name.replace("U", "Z")
 
     def __repr__(self) -> str:
-        return f"{self.name}_{self.location}"
+        if len(self.location) > 0:
+            return f"{self.name}_{self.location}"
+        else:
+            return self.name
 
     def get_orientation(self) -> str:
         if "_" in self.name:

--- a/src/noisepy/seis/main.py
+++ b/src/noisepy/seis/main.py
@@ -38,14 +38,15 @@ def valid_date(d: str) -> str:
 def initialize_fft_params(raw_dir: str) -> ConfigParameters:
     params = ConfigParameters()
     dfile = os.path.join(raw_dir, "download_info.txt")
-    down_info = eval(open(dfile).read())  # TODO: do proper json/yaml serialization
-    params.samp_freq = down_info["samp_freq"]
-    params.freqmin = down_info["freqmin"]
-    params.freqmax = down_info["freqmax"]
-    params.start_date = down_info["start_date"]
-    params.end_date = down_info["end_date"]
-    params.inc_hours = down_info["inc_hours"]
-    params.ncomp = down_info["ncomp"]
+    if os.path.isfile(dfile):
+        down_info = eval(open(dfile).read())  # TODO: do proper json/yaml serialization
+        params.samp_freq = down_info["samp_freq"]
+        params.freqmin = down_info["freqmin"]
+        params.freqmax = down_info["freqmax"]
+        params.start_date = down_info["start_date"]
+        params.end_date = down_info["end_date"]
+        params.inc_hours = down_info["inc_hours"]
+        params.ncomp = down_info["ncomp"]
     return params
 
 


### PR DESCRIPTION
Feature: Allow an optional argument to the `cross_correlate` function to limit the channels used.

Bug fixes:
- Fix file name from channel name 
- Cache the inventory in memory, since reading the disk cache is still expensive
- Use default config if now `download.txt` is available