### PR TITLE
XMLStationChannelCatalog implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Cache location for inventory (used by FDSNChannelCatalog)
+noisepy_cache/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "request": "launch",
       "module": "pytest",
       "args": [
-        "${workspaceFolder}/tests"
+        "${workspaceFolder}/tests/"
       ]
     },
     {
@@ -27,8 +27,35 @@
         "cross_correlate",
         "--freq_norm",
         "rma",
+        "--raw_data_path",
+        "${userHome}/s3tmp/scedc/2022/002",
+        "--ccf_path",
+        "${userHome}/ccfs3tmp/",
+        "--stations",
+        "SBC,RIO,DEV,HEC,RLR,SVD,RPV,BAK",
+        "--xml_path",
+        "/Users/carlosg/s3tmp/FDSNstationXML"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
+      "name": "Python: download",
+      "type": "python",
+      "request": "launch",
+      "module": "noisepy.seis.main",
+      "args": [
+        "download",
+        "--start",
+        "2019_02_01_00_00_00",
+        "--end",
+        "2019_02_01_01_00_00",
+        "--stations",
+        "ARV,BAK",
+        "--inc_hours",
+        "1",
         "--path",
-        "${userHome}/s3tmp/tiny"
+        "${userHome}/tmp/"
       ],
       "console": "integratedTerminal",
       "justMyCode": true

--- a/src/noisepy/seis/S1_fft_cc_MPI.py
+++ b/src/noisepy/seis/S1_fft_cc_MPI.py
@@ -2,7 +2,7 @@ import gc
 import logging
 import sys
 import time
-from typing import Callable, List, Tuple
+from typing import List, Tuple
 
 import numpy as np
 import obspy
@@ -55,7 +55,6 @@ def cross_correlate(
     raw_store: RawDataStore,
     fft_params: ConfigParameters,
     cc_store: CrossCorrelationDataStore,
-    channel_filter: Callable[[Channel], bool] = None,
 ):
     """
     Perform the cross-correlation analysis
@@ -64,13 +63,9 @@ def cross_correlate(
                 raw_store: Store to load data from
                 fft_params: Parameters for the FFT calculations
                 cc_store: Store for saving cross correlations
-                channel_filter: Function to decide whether a channel should be used or not,
-                                if None, all channels are used
 
     """
 
-    if channel_filter is None:
-        channel_filter = lambda s: True  # noqa: E731
     #######################################
     # #########PROCESSING SECTION##########
     #######################################
@@ -106,7 +101,6 @@ def cross_correlate(
 
         # ###########LOADING NOISE DATA AND DO FFT##################
         channels = raw_store.get_channels(ts)
-        channels = list(filter(channel_filter, channels))
         ch_data_tuples = _read_channels(ts, raw_store, channels, fft_params.samp_freq)
         ch_data_tuples = preprocess(ch_data_tuples, raw_store, fft_params, ts)
 

--- a/src/noisepy/seis/__init__.py
+++ b/src/noisepy/seis/__init__.py
@@ -22,5 +22,5 @@ The main functions exported by the package are:
 - plotting_modules: Utility functions for plotting the data
 """
 
-logging.basicConfig(level=logging.DEBUG, format="%(asctime)s %(levelname)s %(module)s %(funcName)s %(message)s")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(module)s %(funcName)s %(message)s")
 logger = logging.getLogger(__name__)

--- a/src/noisepy/seis/noise_module.py
+++ b/src/noisepy/seis/noise_module.py
@@ -288,7 +288,7 @@ def preprocess_raw(
                 "date": starttime,
                 "units": "DIS",
             }
-            st.simulate(paz_remove=None, pre_filt=pre_filt, seedresp=seedresp[0])
+            st.simulate(paz_remove=None, pre_filt=pre_filt, seedresp=seedresp)
 
         elif rm_resp == "polozeros":
             print("remove response using polos and zeros")

--- a/tests/data/CI_YAQ.xml
+++ b/tests/data/CI_YAQ.xml
@@ -1,0 +1,69 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<fsx:FDSNStationXML xmlns:fsx="http://www.fdsn.org/xml/station/1" xmlns:sis="http://anss-sis.scsn.org/xml/ext-stationxml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:schemaLocation="http://www.fdsn.org/xml/station/1 http://www.fdsn.org/xml/station/fdsn-station-1.1.xsd">
+  <fsx:Source>ANSS Station Information System</fsx:Source>
+  <fsx:Sender>ANSS Station Information System</fsx:Sender>
+  <fsx:Created>2015-10-21T17:51:40.481255Z</fsx:Created>
+  <fsx:Network code="CI">
+    <fsx:Description>Southern California Seismic Network</fsx:Description>
+    <fsx:TotalNumberStations>725</fsx:TotalNumberStations>
+    <fsx:SelectedNumberStations>1</fsx:SelectedNumberStations>
+    <fsx:Station code="YAQ" startDate="1981-04-04T00:00:00Z" endDate="1998-02-02T00:00:00Z">
+      <fsx:Latitude>33.166610</fsx:Latitude>
+      <fsx:Longitude>-116.353860</fsx:Longitude>
+      <fsx:Elevation>430.0</fsx:Elevation>
+      <fsx:Site>
+        <fsx:Name>YAQUI MEADOWS</fsx:Name>
+      </fsx:Site>
+      <fsx:Operator>
+        <fsx:Agency>SCSN-CA</fsx:Agency>
+      </fsx:Operator>
+      <fsx:CreationDate>1981-04-04T00:00:00Z</fsx:CreationDate>
+      <fsx:TotalNumberChannels>1</fsx:TotalNumberChannels>
+      <fsx:SelectedNumberChannels>1</fsx:SelectedNumberChannels>
+      <fsx:Channel code="EHZ" startDate="1981-04-04T00:00:00Z" endDate="1998-02-02T00:00:00Z" locationCode="">
+        <fsx:Comment>
+          <fsx:Value>Historical epoch</fsx:Value>
+          <fsx:BeginEffectiveTime>1981-04-04T00:00:00Z</fsx:BeginEffectiveTime>
+          <fsx:EndEffectiveTime>1998-02-02T00:00:00Z</fsx:EndEffectiveTime>
+          <fsx:Author>
+            <fsx:Name>sis2.0_migration-SCSN LEGACY DB-SIS</fsx:Name>
+          </fsx:Author>
+        </fsx:Comment>
+        <fsx:Latitude>33.166610</fsx:Latitude>
+        <fsx:Longitude>-116.353860</fsx:Longitude>
+        <fsx:Elevation>430.0</fsx:Elevation>
+        <fsx:Depth>0.0</fsx:Depth>
+        <fsx:Azimuth>0.0</fsx:Azimuth>
+        <fsx:Dip>-90.0</fsx:Dip>
+        <fsx:Type>GEOPHYSICAL</fsx:Type>
+        <fsx:SampleRate>9.990000000000E+02</fsx:SampleRate>
+
+        <fsx:CalibrationUnits>
+          <fsx:Name>A</fsx:Name>
+          <fsx:Description>Electric Current in Amperes</fsx:Description>
+        </fsx:CalibrationUnits>
+        <fsx:Sensor>
+          <fsx:Type>UNKNOWN:UNKNOWN_VEL:YAQ_EHZ</fsx:Type>
+          <fsx:Manufacturer>UNKNOWN</fsx:Manufacturer>
+          <fsx:Model>UNKNOWN_VEL</fsx:Model>
+          <fsx:SerialNumber>YAQ_EHZ</fsx:SerialNumber>
+          <fsx:CalibrationDate>1981-04-04T00:00:00Z</fsx:CalibrationDate>
+        </fsx:Sensor>
+        <fsx:Response>
+          <fsx:InstrumentSensitivity>
+            <fsx:Value>1.000000000000E+00</fsx:Value>
+            <fsx:Frequency>1.000000000000E+00</fsx:Frequency>
+            <fsx:InputUnits>
+              <fsx:Name>m/s</fsx:Name>
+              <fsx:Description>Velocity in meters per second</fsx:Description>
+            </fsx:InputUnits>
+            <fsx:OutputUnits>
+              <fsx:Name>V</fsx:Name>
+              <fsx:Description>Voltage in Volts</fsx:Description>
+            </fsx:OutputUnits>
+          </fsx:InstrumentSensitivity>
+        </fsx:Response>
+      </fsx:Channel>
+    </fsx:Station>
+  </fsx:Network>
+</fsx:FDSNStationXML>

--- a/tests/test_channelcatalog.py
+++ b/tests/test_channelcatalog.py
@@ -6,7 +6,11 @@ import pytest
 from datetimerange import DateTimeRange
 from obspy import UTCDateTime
 
-from noisepy.seis.channelcatalog import ChannelCatalog, CSVChannelCatalog
+from noisepy.seis.channelcatalog import (
+    ChannelCatalog,
+    CSVChannelCatalog,
+    XMLStationChannelCatalog,
+)
 from noisepy.seis.datatypes import Channel, ChannelType, Station
 from noisepy.seis.noise_module import stats2inv_mseed
 
@@ -55,3 +59,13 @@ def test_frominventory(station: str, ch: str, lat: float, lon: float, elev: floa
     assert full_ch.station.lat == lat
     assert full_ch.station.lon == lon
     assert full_ch.station.elevation == elev
+
+
+def test_XMLStationChannelCatalog():
+    dir = os.path.join(os.path.dirname(__file__), "./data/")
+    cat = XMLStationChannelCatalog(dir)
+    empty_inv = cat.get_inventory(DateTimeRange(), Station("non-existent", "non-existent", 0, 0, 0, ""))
+    assert len(empty_inv) == 0
+    yaq_inv = cat.get_inventory(DateTimeRange(), Station("CI", "YAQ", 0, 0, 0, ""))
+    assert len(yaq_inv) == 1
+    assert len(yaq_inv.networks[0].stations) == 1


### PR DESCRIPTION
- ChannelCatalog implementation that reads XML files obtained from `s3://scedc-pds/FDSNstationXML` for inventory information.
- Moved the channel filtering from S1 into the `SCEDCS3DataStore` to avoid fully loading a large number of channels (>4000), when only a subset (~10) is used
- Updates to the CLI (`main.py`) to use the new channel catalog and take the list of stations to filter on for the `cross_correlation` step. 