### PR TITLE
Support reading directly from S3 buckets

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,6 +40,27 @@
       "justMyCode": true
     },
     {
+      "name": "Python: S3 cross_correlate",
+      "type": "python",
+      "request": "launch",
+      "module": "noisepy.seis.main",
+      "args": [
+        "cross_correlate",
+        "--freq_norm",
+        "rma",
+        "--raw_data_path",
+        "s3://scedc-pds/continuous_waveforms/2002/2002_002/",
+        "--ccf_path",
+        "${userHome}/ccfs3tmp/",
+        "--stations",
+        "SBC,RIO,DEV,HEC,RLR,SVD,RPV,BAK",
+        "--xml_path",
+        "s3://scedc-pds/FDSNstationXML/CI/"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
       "name": "Python: download",
       "type": "python",
       "request": "launch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ dependencies = [
     "pyasdf>=0.7.5",
     "pycwt>=0.3.0a22",
     "diskcache>=5.5",
-    "s3fs==2023.4.0",
+    "fsspec>=2023.4.0",
+    "s3fs>=2023.4.0",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "pyasdf>=0.7.5",
     "pycwt>=0.3.0a22",
     "diskcache>=5.5",
+    "s3fs==2023.4.0",
 ]
 
 

--- a/src/noisepy/seis/channelcatalog.py
+++ b/src/noisepy/seis/channelcatalog.py
@@ -11,6 +11,7 @@ from obspy import UTCDateTime, read_inventory
 from obspy.clients.fdsn import Client
 
 from .datatypes import Channel, Station
+from .utils import get_filesystem
 
 logger = logging.getLogger(__name__)
 
@@ -57,22 +58,24 @@ class XMLStationChannelCatalog(ChannelCatalog):
     A channel catalog that reads <station>.XML files from a directory
     """
 
-    def __init__(self, xmldir: str) -> None:
+    def __init__(self, xmlpath: str) -> None:
         super().__init__()
-        self.xmldir = xmldir
-        if not os.path.exists(self.xmldir):
-            raise Exception(f"The XML Station file directory '{xmldir}' doesn't exist")
+        self.xmlpath = xmlpath
+        self.fs = get_filesystem(xmlpath)
+        if not self.fs.exists(self.xmlpath):
+            raise Exception(f"The XML Station file directory '{xmlpath}' doesn't exist")
 
     def get_inventory(self, timespan: DateTimeRange, station: Station) -> obspy.Inventory:
-        xmlfile = os.path.join(self.xmldir, f"{station.network}_{station.name}.xml")
+        xmlfile = os.path.join(self.xmlpath, f"{station.network}_{station.name}.xml")
         return self._get_inventory_from_file(xmlfile)
 
     @lru_cache
     def _get_inventory_from_file(self, xmlfile):
-        if not os.path.exists(xmlfile):
+        if not self.fs.exists(xmlfile):
             logger.warning(f"Could not find StationXML file {xmlfile}. Returning empty Inventory()")
             return obspy.Inventory()
-        return read_inventory(xmlfile)
+        with self.fs.open(xmlfile) as f:
+            return read_inventory(f)
 
 
 class FDSNChannelCatalog(ChannelCatalog):

--- a/src/noisepy/seis/channelcatalog.py
+++ b/src/noisepy/seis/channelcatalog.py
@@ -55,7 +55,7 @@ class ChannelCatalog(ABC):
 
 class XMLStationChannelCatalog(ChannelCatalog):
     """
-    A channel catalog that reads <station>.XML files from a directory
+    A channel catalog that reads <station>.XML files from a directory or an s3://... bucket path.
     """
 
     def __init__(self, xmlpath: str) -> None:

--- a/src/noisepy/seis/channelcatalog.py
+++ b/src/noisepy/seis/channelcatalog.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from abc import ABC, abstractmethod
 from functools import lru_cache
 
@@ -11,7 +10,7 @@ from obspy import UTCDateTime, read_inventory
 from obspy.clients.fdsn import Client
 
 from .datatypes import Channel, Station
-from .utils import get_filesystem
+from .utils import fs_join, get_filesystem
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +65,7 @@ class XMLStationChannelCatalog(ChannelCatalog):
             raise Exception(f"The XML Station file directory '{xmlpath}' doesn't exist")
 
     def get_inventory(self, timespan: DateTimeRange, station: Station) -> obspy.Inventory:
-        xmlfile = os.path.join(self.xmlpath, f"{station.network}_{station.name}.xml")
+        xmlfile = fs_join(self.xmlpath, f"{station.network}_{station.name}.xml")
         return self._get_inventory_from_file(xmlfile)
 
     @lru_cache

--- a/src/noisepy/seis/channelcatalog.py
+++ b/src/noisepy/seis/channelcatalog.py
@@ -54,7 +54,7 @@ class ChannelCatalog(ABC):
 
 class XMLStationChannelCatalog(ChannelCatalog):
     """
-    A channel catalog that reads <station>.XML files from a directory or an s3://... bucket path.
+    A channel catalog that reads <station>.XML files from a directory or an s3://... bucket url path.
     """
 
     def __init__(self, xmlpath: str) -> None:

--- a/src/noisepy/seis/main.py
+++ b/src/noisepy/seis/main.py
@@ -14,7 +14,7 @@ from .S0A_download_ASDF_MPI import download
 from .S1_fft_cc_MPI import cross_correlate
 from .S2_stacking import stack
 from .scedc_s3store import SCEDCS3DataStore
-from .utils import get_filesystem
+from .utils import fs_join, get_filesystem
 
 # Utility running the different steps from the command line. Defines the arguments for each step
 
@@ -37,7 +37,7 @@ def valid_date(d: str) -> str:
 
 def initialize_fft_params(raw_dir: str) -> ConfigParameters:
     params = ConfigParameters()
-    dfile = os.path.join(raw_dir, "download_info.txt")
+    dfile = fs_join(raw_dir, "download_info.txt")
     if os.path.isfile(dfile):
         down_info = eval(open(dfile).read())  # TODO: do proper json/yaml serialization
         params.samp_freq = down_info["samp_freq"]
@@ -62,7 +62,7 @@ def create_raw_store(raw_dir: str, sta_list: List[str], xml_path: str):
     fs = get_filesystem(raw_dir)
 
     def count(pat):
-        return len(fs.glob(os.path.join(raw_dir, pat)))
+        return len(fs.glob(fs_join(raw_dir, pat)))
 
     # Use heuristics around which store to use by the files present
     if count("*.h5") > 0:

--- a/src/noisepy/seis/main.py
+++ b/src/noisepy/seis/main.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import typing
 from enum import Enum
-from glob import glob
 from typing import Any, Callable, List
 
 import obspy
@@ -15,6 +14,7 @@ from .S0A_download_ASDF_MPI import download
 from .S1_fft_cc_MPI import cross_correlate
 from .S2_stacking import stack
 from .scedc_s3store import SCEDCS3DataStore
+from .utils import get_filesystem
 
 # Utility running the different steps from the command line. Defines the arguments for each step
 
@@ -59,8 +59,10 @@ def get_channel_filter(sta_list: List[str]) -> Callable[[Channel], bool]:
 
 
 def create_raw_store(raw_dir: str, sta_list: List[str], xml_path: str):
+    fs = get_filesystem(raw_dir)
+
     def count(pat):
-        return len(glob(os.path.join(raw_dir, pat)))
+        return len(fs.glob(os.path.join(raw_dir, pat)))
 
     # Use heuristics around which store to use by the files present
     if count("*.h5") > 0:

--- a/src/noisepy/seis/scedc_s3store.py
+++ b/src/noisepy/seis/scedc_s3store.py
@@ -30,7 +30,7 @@ class SCEDCS3DataStore(RawDataStore):
     def __init__(self, path: str, chan_catalog: ChannelCatalog, channel_filter: Callable[[Channel], bool] = None):
         """
         Parameters:
-            path: path to look for ms files. Can be a local file directory or an s3://... path
+            path: path to look for ms files. Can be a local file directory or an s3://... url path
             chan_catalog: ChannelCatalog to retrieve inventory information for the channels
             channel_filter: Function to decide whether a channel should be used or not,
                             if None, all channels are used

--- a/src/noisepy/seis/scedc_s3store.py
+++ b/src/noisepy/seis/scedc_s3store.py
@@ -1,4 +1,3 @@
-import glob
 import logging
 import os
 import re
@@ -12,6 +11,7 @@ from noisepy.seis.channelcatalog import ChannelCatalog
 from noisepy.seis.stores import RawDataStore
 
 from .datatypes import Channel, ChannelData, ChannelType, Station
+from .utils import get_filesystem
 
 logger = logging.getLogger(__name__)
 
@@ -27,20 +27,22 @@ class SCEDCS3DataStore(RawDataStore):
     # for checking the filename has the form: CIGMR__LHN___2022002.ms
     file_re = re.compile(r".*[0-9]{7}\.ms$", re.IGNORECASE)
 
-    def __init__(self, directory: str, chan_catalog: ChannelCatalog, channel_filter: Callable[[Channel], bool] = None):
+    def __init__(self, path: str, chan_catalog: ChannelCatalog, channel_filter: Callable[[Channel], bool] = None):
         """
         Parameters:
-            directory: directory to look for ms files
+            path: path to look for ms files. Can be a local file directory or an s3://... path
             chan_catalog: ChannelCatalog to retrieve inventory information for the channels
             channel_filter: Function to decide whether a channel should be used or not,
                             if None, all channels are used
         """
         super().__init__()
-        self.directory = directory
+        self.fs = get_filesystem(path)
+        self.path = path
         self.channel_catalog = chan_catalog
         if channel_filter is None:
             channel_filter = lambda s: True  # noqa: E731
-        msfiles = [f for f in glob.glob(os.path.join(directory, "*.ms")) if self.file_re.match(f) is not None]
+
+        msfiles = [f for f in self.fs.glob(os.path.join(path, "*.ms")) if self.file_re.match(f) is not None]
         # store a dict of {timerange: list of channels}
         self.channels = {}
         timespans = []
@@ -72,12 +74,13 @@ class SCEDCS3DataStore(RawDataStore):
             f"{chan.station.network}{chan.station.name.ljust(5, '_')}{chan.type.name}"
             f"{chan.station.location.ljust(3, '_')}"
         )
-        filename = os.path.join(self.directory, f"{chan_str}{timespan.start_datetime.strftime('%Y%j')}.ms")
-        if not os.path.exists(filename):
+        filename = os.path.join(self.path, f"{chan_str}{timespan.start_datetime.strftime('%Y%j')}.ms")
+        if not self.fs.exists(filename):
             logger.warning(f"Could not find file {filename}")
             return ChannelData.empty()
 
-        stream = obspy.read(filename)
+        with self.fs.open(filename) as f:
+            stream = obspy.read(f)
         return ChannelData(stream)
 
     def get_inventory(self, timespan: DateTimeRange, station: Station) -> obspy.Inventory:

--- a/src/noisepy/seis/scedc_s3store.py
+++ b/src/noisepy/seis/scedc_s3store.py
@@ -11,7 +11,7 @@ from noisepy.seis.channelcatalog import ChannelCatalog
 from noisepy.seis.stores import RawDataStore
 
 from .datatypes import Channel, ChannelData, ChannelType, Station
-from .utils import get_filesystem
+from .utils import fs_join, get_filesystem
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ class SCEDCS3DataStore(RawDataStore):
         if channel_filter is None:
             channel_filter = lambda s: True  # noqa: E731
 
-        msfiles = [f for f in self.fs.glob(os.path.join(path, "*.ms")) if self.file_re.match(f) is not None]
+        msfiles = [f for f in self.fs.glob(fs_join(path, "*.ms")) if self.file_re.match(f) is not None]
         # store a dict of {timerange: list of channels}
         self.channels = {}
         timespans = []
@@ -74,7 +74,7 @@ class SCEDCS3DataStore(RawDataStore):
             f"{chan.station.network}{chan.station.name.ljust(5, '_')}{chan.type.name}"
             f"{chan.station.location.ljust(3, '_')}"
         )
-        filename = os.path.join(self.path, f"{chan_str}{timespan.start_datetime.strftime('%Y%j')}.ms")
+        filename = fs_join(self.path, f"{chan_str}{timespan.start_datetime.strftime('%Y%j')}.ms")
         if not self.fs.exists(filename):
             logger.warning(f"Could not find file {filename}")
             return ChannelData.empty()

--- a/src/noisepy/seis/utils.py
+++ b/src/noisepy/seis/utils.py
@@ -7,9 +7,11 @@ import fsspec
 S3_SCHEME = "s3"
 
 
-def get_filesystem(path: str) -> fsspec.AbstractFileSystem:
+def get_filesystem(path: str, storage_options: dict = {}) -> fsspec.AbstractFileSystem:
     url = urlparse(path)
-    return fsspec.filesystem(S3_SCHEME, anon=True) if url.scheme == S3_SCHEME else fsspec.filesystem("file")
+    if url.scheme == S3_SCHEME:
+        storage_options = {'anon': True}
+    return fsspec.filesystem(url.scheme, **storage_options)
 
 
 def fs_join(path1: str, path2: str) -> str:

--- a/src/noisepy/seis/utils.py
+++ b/src/noisepy/seis/utils.py
@@ -1,7 +1,19 @@
+import os
+import posixpath
+from urllib.parse import urlparse
+
 import fsspec
 
-S3PREFIX = "s3"
+S3_SCHEME = "s3"
 
 
 def get_filesystem(path: str) -> fsspec.AbstractFileSystem:
-    return fsspec.filesystem(S3PREFIX, anon=True) if path.startswith(S3PREFIX) else fsspec.filesystem("file")
+    url = urlparse(path)
+    return fsspec.filesystem(S3_SCHEME, anon=True) if url.scheme == S3_SCHEME else fsspec.filesystem("file")
+
+
+def fs_join(path1: str, path2: str) -> str:
+    if path1.startswith(S3_SCHEME):
+        return posixpath.join(path1, path2)
+    else:
+        return os.path.join(path1, path2)

--- a/src/noisepy/seis/utils.py
+++ b/src/noisepy/seis/utils.py
@@ -9,6 +9,7 @@ ANON_ARG = "anon"
 
 
 def get_filesystem(path: str, storage_options: dict = {}) -> fsspec.AbstractFileSystem:
+    """Construct an fsspec filesystem for the given path"""
     url = urlparse(path)
     # default to anonymous access for S3 if the this is not already specified
     if url.scheme == S3_SCHEME and ANON_ARG not in storage_options:
@@ -17,7 +18,9 @@ def get_filesystem(path: str, storage_options: dict = {}) -> fsspec.AbstractFile
 
 
 def fs_join(path1: str, path2: str) -> str:
-    if path1.startswith(S3_SCHEME):
+    """Helper for joining two paths that can handle both S3 URLs and local file system paths"""
+    url = urlparse(path1)
+    if url.scheme == S3_SCHEME:
         return posixpath.join(path1, path2)
     else:
         return os.path.join(path1, path2)

--- a/src/noisepy/seis/utils.py
+++ b/src/noisepy/seis/utils.py
@@ -1,0 +1,7 @@
+import fsspec
+
+S3PREFIX = "s3"
+
+
+def get_filesystem(path: str) -> fsspec.AbstractFileSystem:
+    return fsspec.filesystem(S3PREFIX, anon=True) if path.startswith(S3PREFIX) else fsspec.filesystem("file")

--- a/src/noisepy/seis/utils.py
+++ b/src/noisepy/seis/utils.py
@@ -5,12 +5,14 @@ from urllib.parse import urlparse
 import fsspec
 
 S3_SCHEME = "s3"
+ANON_ARG = "anon"
 
 
 def get_filesystem(path: str, storage_options: dict = {}) -> fsspec.AbstractFileSystem:
     url = urlparse(path)
-    if url.scheme == S3_SCHEME:
-        storage_options = {'anon': True}
+    # default to anonymous access for S3 if the this is not already specified
+    if url.scheme == S3_SCHEME and ANON_ARG not in storage_options:
+        storage_options = {ANON_ARG: True}
     return fsspec.filesystem(url.scheme, **storage_options)
 
 

--- a/tests/test_channelcatalog.py
+++ b/tests/test_channelcatalog.py
@@ -61,9 +61,12 @@ def test_frominventory(station: str, ch: str, lat: float, lon: float, elev: floa
     assert full_ch.station.elevation == elev
 
 
-def test_XMLStationChannelCatalog():
-    dir = os.path.join(os.path.dirname(__file__), "./data/")
-    cat = XMLStationChannelCatalog(dir)
+xmlpaths = [os.path.join(os.path.dirname(__file__), "./data/"), "s3://scedc-pds/FDSNstationXML/CI/"]
+
+
+@pytest.mark.parametrize("path", xmlpaths)
+def test_XMLStationChannelCatalog(path):
+    cat = XMLStationChannelCatalog(path)
     empty_inv = cat.get_inventory(DateTimeRange(), Station("non-existent", "non-existent", 0, 0, 0, ""))
     assert len(empty_inv) == 0
     yaq_inv = cat.get_inventory(DateTimeRange(), Station("CI", "YAQ", 0, 0, 0, ""))

--- a/tests/test_scedc_s3store.py
+++ b/tests/test_scedc_s3store.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime, timezone
 
 import pytest
@@ -19,11 +20,10 @@ def test_parsefilename(file: str, expected: DateTimeRange):
     assert expected == SCEDCS3DataStore._parse_timespan(file)
 
 
-@pytest.fixture
-def store():
-    import os
-
-    return SCEDCS3DataStore(os.path.join(os.path.dirname(__file__), "./data/s3scedc"), MockCatalog())
+data_paths = [
+    os.path.join(os.path.dirname(__file__), "./data/s3scedc"),
+    "s3://scedc-pds/continuous_waveforms/2022/2022_002/",
+]
 
 
 read_channels = [
@@ -31,6 +31,11 @@ read_channels = [
     (SCEDCS3DataStore._parse_channel("CIFOX2_LHZ___2022002.ms")),
     (SCEDCS3DataStore._parse_channel("CINCH__LHZ___2022002.ms")),
 ]
+
+
+@pytest.fixture(params=data_paths)
+def store(request):
+    return SCEDCS3DataStore(request.param, MockCatalog(), lambda ch: ch in read_channels)
 
 
 @pytest.mark.parametrize("channel", read_channels)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+import pytest
+
+from noisepy.seis.utils import fs_join
+
+paths = [
+    ("/dir/", "file.txt", "/dir/file.txt"),
+    ("../relative", "file.json", "../relative/file.json"),
+    ("s3://bucket/path", "file.xml", "s3://bucket/path/file.xml"),
+]
+
+
+@pytest.mark.parametrize("path1, path2, expected", paths)
+def test_fs_join(path1: str, path2: str, expected: str):
+    assert expected == fs_join(path1, path2)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,12 +17,12 @@ def test_fs_join(path1: str, path2: str, expected: str):
 
 
 fs_types = [
-    ("s3://bucket/path", type(S3FileSystem())),
-    ("/some/file", type(LocalFileSystem())),
-    ("s3/local/file", type(LocalFileSystem())),
+    ("s3://bucket/path", S3FileSystem),
+    ("/some/file", LocalFileSystem),
+    ("s3/local/file", LocalFileSystem),
 ]
 
 
 @pytest.mark.parametrize("path, fs_type", fs_types)
 def test_get_filesystem(path, fs_type):
-    assert type(get_filesystem(path)) == fs_type
+    assert isinstance(get_filesystem(path), fs_type)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 import pytest
+from fsspec.implementations.local import LocalFileSystem
+from s3fs import S3FileSystem
 
-from noisepy.seis.utils import fs_join
+from noisepy.seis.utils import fs_join, get_filesystem
 
 paths = [
     ("/dir/", "file.txt", "/dir/file.txt"),
@@ -12,3 +14,15 @@ paths = [
 @pytest.mark.parametrize("path1, path2, expected", paths)
 def test_fs_join(path1: str, path2: str, expected: str):
     assert expected == fs_join(path1, path2)
+
+
+fs_types = [
+    ("s3://bucket/path", type(S3FileSystem())),
+    ("/some/file", type(LocalFileSystem())),
+    ("s3/local/file", type(LocalFileSystem())),
+]
+
+
+@pytest.mark.parametrize("path, fs_type", fs_types)
+def test_get_filesystem(path, fs_type):
+    assert type(get_filesystem(path)) == fs_type


### PR DESCRIPTION
- Replace direct filesystem access with `fsspec` to support both S3 and local files
- Update unit tests to verify both local data and S3
- Add debug configuration for S3 case in `launch.json`

Test run:
```
$ noisepy cross_correlate --raw_data_path s3://scedc-pds/continuous_waveforms/2002/2002_002/ --stations "SBC,RIO,DEV,HEC,RLR,SVD,RPV,BAK" --xml_path "s3://scedc-pds/FDSNstationXML/CI/" --freq_norm rma 

2023-05-05 11:04:52,548 INFO scedc_s3store __init__ Init: 1 timespans and 42 channels
2023-05-05 11:05:11,349 INFO S1_fft_cc_MPI _filter_channel_data Picked 20.0 as the closest sampling frequence to 20. Filtered to 21/42 channels
unreadable garbarge 9
it takes  75.59s to process the chunk of 2002-01-02T00:00:00+0000 - 2002-01-03T00:00:00+0000
it takes  75.59s to process step 1 in total
```