### PR TITLE
Channel filter helper and S0 client parameter

### DIFF
--- a/src/noisepy/seis/S0A_download_ASDF_MPI.py
+++ b/src/noisepy/seis/S0A_download_ASDF_MPI.py
@@ -62,10 +62,8 @@ Enjoy the NoisePy journey!
 #########################################################
 ################ PARAMETER SECTION ######################
 #########################################################
-tt0 = time.time()
 
 # download parameters
-client = Client("SCEDC")  # client/data center. see https://docs.obspy.org/packages/obspy.clients.fdsn.html for a list
 
 # get rough estimate of memory needs to ensure it now below up in S1
 MAX_MEM = 5.0  # maximum memory allowed per core in GB
@@ -79,7 +77,12 @@ def download(
     chan_list: List[str],
     sta_list: List[str],
     prepro_para: ConfigParameters,
+    client_url_key: str = "SCEDC",
 ):
+    # client/data center. see https://docs.obspy.org/packages/obspy.clients.fdsn.html for a list
+    client = Client(client_url_key)
+
+    tt0 = time.time()
     dlist = os.path.join(direc, "station.txt")  # CSV file for station location info
     prepro_para.respdir = os.path.join(
         direc, "../resp"

--- a/src/noisepy/seis/scedc_s3store.py
+++ b/src/noisepy/seis/scedc_s3store.py
@@ -16,6 +16,19 @@ from .utils import fs_join, get_filesystem
 logger = logging.getLogger(__name__)
 
 
+def channel_filter(stations: List[str], ch_prefix: str) -> Callable[[Channel], bool]:
+    """
+    Helper function for creating a channel filter to be used in the constructor of the store.
+    This filter uses a list of allowed station name along with a channel filter prefix.
+    """
+    sta_set = set(stations)
+
+    def filter(ch: Channel) -> bool:
+        return ch.station.name in sta_set and ch.type.name.lower().startswith(ch_prefix.lower())
+
+    return filter
+
+
 class SCEDCS3DataStore(RawDataStore):
     """
     A data store implementation to read from a directory of miniSEED (.ms) files from the SCEDC S3 bucket.


### PR DESCRIPTION
Two small changes

- Allow passing a `client_url_key` parameter to the `download` function, with `"SCEDC"` as the defautl.
- A helper for filtering channels in cross correlation, so a lambda is not needed in the common case. 

I.e., instead of:
```
SCEDCS3DataStore(S3_DATA, catalog, lambda c: c.station.name in stations and c.type.name.startswith("BH"))
```
It can be:
```
SCEDCS3DataStore(S3_DATA, catalog, channel_filter(stations, "BH"))
```
