### PR TITLE
RFC: TimeLogger helper class

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -75,7 +75,7 @@
         "ARV,BAK",
         "--inc_hours",
         "1",
-        "--path",
+        "--raw_data_path",
         "${userHome}/tmp/"
       ],
       "console": "integratedTerminal",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,25 @@
       "justMyCode": true
     },
     {
+      "name": "Python: stack",
+      "type": "python",
+      "request": "launch",
+      "module": "noisepy.seis.main",
+      "args": [
+        "stack",
+        "--raw_data_path",
+        "${userHome}/runner_temp/RAW_DATA",
+        "--ccf_path",
+        "${userHome}/runner_temp/CCF",
+        "--stack_path",
+        "/Users/carlosg/runner_temp/STACK",
+        "--method",
+        "linear"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
       "name": "Python: cross_correlate",
       "type": "python",
       "request": "launch",

--- a/src/noisepy/seis/S1_fft_cc_MPI.py
+++ b/src/noisepy/seis/S1_fft_cc_MPI.py
@@ -95,8 +95,10 @@ def cross_correlate(
         if cc_store.is_done(ts):
             continue
 
-        # ###########LOADING NOISE DATA AND DO FFT##################
-        t_chunk = tlog.reset()
+        """
+        LOADING NOISE DATA AND DO FFT
+        """
+        t_chunk = tlog.reset()  # for tracking overall chunk processing time
         channels = raw_store.get_channels(ts)
         tlog.log("get channels")
         ch_data_tuples = _read_channels(ts, raw_store, channels, fft_params.samp_freq)

--- a/src/noisepy/seis/S1_fft_cc_MPI.py
+++ b/src/noisepy/seis/S1_fft_cc_MPI.py
@@ -1,7 +1,6 @@
 import gc
 import logging
 import sys
-import time
 from typing import List, Tuple
 
 import numpy as np
@@ -14,6 +13,7 @@ from noisepy.seis.datatypes import Channel, ChannelData, ConfigParameters
 
 from . import noise_module
 from .stores import CrossCorrelationDataStore, RawDataStore
+from .utils import TimeLogger
 
 logger = logging.getLogger(__name__)
 # ignore warnings
@@ -70,7 +70,9 @@ def cross_correlate(
     # #########PROCESSING SECTION##########
     #######################################
 
-    tt0 = time.time()
+    tlog = TimeLogger(logger, logging.INFO)
+    # tlog.enabled = False
+    t_all = tlog.reset()
     # --------MPI---------
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
@@ -94,18 +96,18 @@ def cross_correlate(
 
     # MPI loop: loop through each user-defined time chunk
     for ick in range(rank, splits, size):
-        t10 = time.time()
         ts = timespans[ick]
         if cc_store.is_done(ts):
             continue
 
         # ###########LOADING NOISE DATA AND DO FFT##################
-        t0 = time.time()
+        t_chunk = tlog.reset()
         channels = raw_store.get_channels(ts)
+        tlog.log("get channels")
         ch_data_tuples = _read_channels(ts, raw_store, channels, fft_params.samp_freq)
-        t01 = time.time()
+        tlog.log("read channel data")
         ch_data_tuples = preprocess(ch_data_tuples, raw_store, fft_params, ts)
-        t02 = time.time()
+        tlog.log("preprocess")
 
         nchannels = len(ch_data_tuples)
         nseg_chunk = check_memory(fft_params, nchannels)
@@ -146,12 +148,11 @@ def cross_correlate(
                 continue
             # in the case of pure deconvolution, we recommend smoothing anyway.
             if fft_params.cc_method == "deconv":
-                t00 = time.time()
+                tlog.reset()
                 # -----------get the smoothed source spectrum for decon later----------
                 sfft1 = noise_module.smooth_source_spect(fft_params, fft1)
                 sfft1 = sfft1.reshape(N, Nfft2)
-                t10 = time.time()
-                logger.debug("smoothing source takes %6.4fs" % (t10 - t00))
+                tlog.log("smoothing source")
             else:
                 sfft1 = fft1.reshape(N, Nfft2)
 
@@ -207,11 +208,11 @@ def cross_correlate(
                     continue
 
                 # ----------- GAME TIME: cross correlation step ---------------
-                t2 = time.time()
+                tlog.reset()
                 corr, tcorr, ncorr = noise_module.correlate(
                     sfft1[bb, :], sfft2[bb, :], fft_params, Nfft, fft_time[iiR][bb]
                 )
-                t3 = time.time()
+                tlog.log("cross-correlate")
 
                 # ---------- OUTPUT: store metadata and data into file ------------
                 coor = {
@@ -223,11 +224,7 @@ def cross_correlate(
                 comp = src_chan.type.get_orientation() + rec_chan.type.get_orientation()
                 parameters = noise_module.cc_parameters(fft_params, coor, tcorr, ncorr, comp)
                 cc_store.append(ts, src_chan, rec_chan, fft_params, parameters, corr)
-                t4 = time.time()
-                logger.debug(
-                    "read S %6.4fs, process %6.4fs, cc %6.4fs, write cc %6.4fs"
-                    % ((t01 - t0), (t02 - t01), (t3 - t2), (t4 - t3))
-                )
+                tlog.log("write cc")
 
                 del fft2, sfft2, receiver_std
             del fft1, sfft1, source_std
@@ -236,15 +233,12 @@ def cross_correlate(
         fft_std = []
         fft_flag = []
         fft_time = []
-        n = gc.collect()
-        print("unreadable garbarge", n)
+        gc.collect()
 
-        t11 = time.time()
-        print("it takes %6.2fs to process the chunk of %s" % (t11 - t10, ts))
+        tlog.log(f"Process the chunk of {ts}", t_chunk)
         cc_store.mark_done(ts)
 
-    tt1 = time.time()
-    print("it takes %6.2fs to process step 1 in total" % (tt1 - tt0))
+    tlog.log("Step 1 in total", t_all)
     comm.barrier()
 
 

--- a/src/noisepy/seis/S1_fft_cc_MPI.py
+++ b/src/noisepy/seis/S1_fft_cc_MPI.py
@@ -66,13 +66,8 @@ def cross_correlate(
 
     """
 
-    #######################################
-    # #########PROCESSING SECTION##########
-    #######################################
-
     tlog = TimeLogger(logger, logging.INFO)
-    # tlog.enabled = False
-    t_all = tlog.reset()
+    t_s1_total = tlog.reset()
     # --------MPI---------
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
@@ -240,7 +235,7 @@ def cross_correlate(
         tlog.log(f"Process the chunk of {ts}", t_chunk)
         cc_store.mark_done(ts)
 
-    tlog.log("Step 1 in total", t_all)
+    tlog.log("Step 1 in total", t_s1_total)
     comm.barrier()
 
 

--- a/src/noisepy/seis/S1_fft_cc_MPI.py
+++ b/src/noisepy/seis/S1_fft_cc_MPI.py
@@ -122,6 +122,7 @@ def cross_correlate(
         # loop through all channels
         N: int
         Nfft2: int
+        tlog.reset()
         for ix_ch, (ch, ch_data) in enumerate(ch_data_tuples):
             # TODO: Below the last values for N and Nfft are used?
             fft_array[ix_ch], fft_std[ix_ch], fft_time[ix_ch], N, Nfft2 = compute_fft(fft_params, ch_data)
@@ -129,6 +130,7 @@ def cross_correlate(
             if not fft_flag[ix_ch]:
                 logger.warning(f"No data available for channel '{ch}', skipped")
         Nfft = Nfft2 * 2
+        tlog.log("Compute FFTs")
 
         # check whether array size is enough
         if np.sum(fft_flag) != nchannels:

--- a/src/noisepy/seis/plotting_modules.py
+++ b/src/noisepy/seis/plotting_modules.py
@@ -697,8 +697,8 @@ def plot_all_moveout(
             dist[ii] = ds.auxiliary_data[dtype][path].parameters["dist"]
             ngood[ii] = ds.auxiliary_data[dtype][path].parameters["ngood"]
             tdata = ds.auxiliary_data[dtype][path].data[indx1:indx2]
-        except Exception:
-            print("continue! cannot read %s " % sfile)
+        except Exception as e:
+            print(f"continue! cannot read {sfile}: {e}")
             continue
 
         data[ii] = bandpass(tdata, freqmin, freqmax, int(1 / dt), corners=4, zerophase=True)

--- a/src/noisepy/seis/utils.py
+++ b/src/noisepy/seis/utils.py
@@ -1,11 +1,14 @@
+import logging
 import os
 import posixpath
+import time
 from urllib.parse import urlparse
 
 import fsspec
 
 S3_SCHEME = "s3"
 ANON_ARG = "anon"
+utils_logger = logging.getLogger(__name__)
 
 
 def get_filesystem(path: str, storage_options: dict = {}) -> fsspec.AbstractFileSystem:
@@ -24,3 +27,24 @@ def fs_join(path1: str, path2: str) -> str:
         return posixpath.join(path1, path2)
     else:
         return os.path.join(path1, path2)
+
+
+class TimeLogger:
+    enabled: bool = True
+
+    def __init__(self, logger: logging.Logger = utils_logger, level: int = logging.DEBUG):
+        self.logger = logger
+        self.level = level
+        self.reset()
+
+    def reset(self) -> float:
+        self.time = time.time()
+        return self.time
+
+    def log(self, message: str = None, start: float = -1.0) -> float:
+        stop = time.time()
+        dt = stop - self.time if start <= 0 else stop - start
+        self.reset()
+        if self.enabled:
+            self.logger.log(self.level, f"TIMING: {dt:6.4f} for {message}")
+        return self.time

--- a/src/noisepy/seis/utils.py
+++ b/src/noisepy/seis/utils.py
@@ -30,9 +30,34 @@ def fs_join(path1: str, path2: str) -> str:
 
 
 class TimeLogger:
+    """
+    A utility class to measure and log the time spent in code fragments. The basic usage is to call::
+
+        tlog.log(message)
+
+    This will measure the time between the last time checkpoint and the call to ``log()``. The
+    checkpoint is updated when:
+    - ``TimeLogger`` instance is created
+    - ``log()`` is called
+    - ``reset()`` is called
+
+    Alternatively, an explicit reference start time may be passed when logging: ``log(message, start_time)``. E.g.::
+
+        start_time = tlog.reset()
+        ...
+        tlog.log("step 1")
+        ...
+        tlog.log("step 2")
+        ...
+        tlog.log("overall", start_time)
+    """
+
     enabled: bool = True
 
     def __init__(self, logger: logging.Logger = utils_logger, level: int = logging.DEBUG):
+        """
+        Create an instance that will use the given logger and logging level to log the times
+        """
         self.logger = logger
         self.level = level
         self.reset()

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -1,0 +1,8 @@
+RUNNER_TEMP=~/test_temp
+rm -rf $RUNNER_TEMP
+noisepy download --start 2019_02_01_00_00_00 --end 2019_02_01_01_00_00 --stations ARV,BAK --inc_hours 1 --raw_data_path $RUNNER_TEMP/RAW_DATA
+noisepy cross_correlate --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --freq_norm rma
+noisepy stack --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --method linear
+rm -rf $RUNNER_TEMP
+noisepy all --start 2019_02_01_00_00_00 --end 2019_02_01_01_00_00 --stations ARV,BAK --inc_hours 1 --raw_data_path $RUNNER_TEMP/RAW_DATA \
+       --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --method linear --freq_norm rma


### PR DESCRIPTION
RFC PR (Request for comments!). We have several places in the code where we measure and log timings. This is an attempt at simplifying things and reducing the amount of code it takes to do this. This PR includes a helper class as well as changes to `S1_fft_cc_MPI.py` to show the usage.


TimeLogger is utility class to measure and log the time spent in code fragments. The basic usage is to call:
```
tlog = TimeLogger()
...
tlog.log(message)
```
This will measure the time between the last time checkpoint and the call to ``log()``. The
checkpoint is updated when:
 - ``TimeLogger`` instance is created
 - ``log()`` is called
 - ``reset()`` is called

Alternatively, an explicit reference start time may be passed when logging: ``log(message, start_time)``. E.g.:
```
start_time = tlog.reset()
sleep(1)
tlog.log("step 1")
sleep(2)
tlog.log("step 2")
sleep(1)
tlog.log("overall", start_time)
```
Would output:
```
2023-05-09 14:04:02,570 INFO utils log TIMING: 1.0020 for step 1
2023-05-09 14:04:04,575 INFO utils log TIMING: 2.0056 for step 2
2023-05-09 14:04:05,579 INFO utils log TIMING: 4.0114 for overall
```