### PR TITLE
Support passing a date range to SCEDCS3Store

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,3 +65,19 @@ jobs:
       working-directory: ./src
       run: |
         noisepy stack --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --method ${{matrix.method}}
+  s3_dates:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Test S3 data for a date range
+      run: |
+        noisepy cross_correlate --raw_data_path s3://scedc-pds/continuous_waveforms/ \
+        --ccf_path $RUNNER_TEMP/CCF_S3 --freq_norm rma \
+        --stations "SBC,RIO" --start 2022_02_02 --end 2022_02_04
+  s3_singlepath:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Test S3 data with a single path
+      run: |
+        noisepy cross_correlate --raw_data_path s3://scedc-pds/continuous_waveforms/2022/2022_002/ \
+        --ccf_path $RUNNER_TEMP/CCF_S3 --freq_norm rma \
+        --stations "SBC,RIO"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,6 +82,7 @@ jobs:
       run: |
         noisepy cross_correlate --raw_data_path s3://scedc-pds/continuous_waveforms/ \
         --ccf_path $RUNNER_TEMP/CCF_S3 --freq_norm rma \
+        --xml_path s3://scedc-pds/FDSNstationXML/CI/ \
         --stations "SBC,RIO" --start 2022_02_02 --end 2022_02_04
   s3_singlepath:
     strategy:
@@ -100,4 +101,5 @@ jobs:
       run: |
         noisepy cross_correlate --raw_data_path s3://scedc-pds/continuous_waveforms/2022/2022_002/ \
         --ccf_path $RUNNER_TEMP/CCF_S3 --freq_norm rma \
+        --xml_path s3://scedc-pds/FDSNstationXML/CI/ \
         --stations "SBC,RIO"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,16 +66,36 @@ jobs:
       run: |
         noisepy stack --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --method ${{matrix.method}}
   s3_dates:
+    strategy:
+      fail-fast: true
+      matrix:
+        python_version: [3.8, 3.11]
     runs-on: ubuntu-22.04
     steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3.3.0
+    - name: Setup NoisePy
+      uses: ./.github/actions/setup
+      with:
+        python-version: ${{matrix.python_version}}
     - name: Test S3 data for a date range
       run: |
         noisepy cross_correlate --raw_data_path s3://scedc-pds/continuous_waveforms/ \
         --ccf_path $RUNNER_TEMP/CCF_S3 --freq_norm rma \
         --stations "SBC,RIO" --start 2022_02_02 --end 2022_02_04
   s3_singlepath:
+    strategy:
+      fail-fast: true
+      matrix:
+        python_version: [3.8, 3.11]
     runs-on: ubuntu-22.04
     steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3.3.0
+    - name: Setup NoisePy
+      uses: ./.github/actions/setup
+      with:
+        python-version: ${{matrix.python_version}}
     - name: Test S3 data with a single path
       run: |
         noisepy cross_correlate --raw_data_path s3://scedc-pds/continuous_waveforms/2022/2022_002/ \

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "request": "launch",
       "module": "pytest",
       "args": [
-        "${workspaceFolder}/tests/"
+        "${workspaceFolder}/tests/test_scedc_s3store.py"
       ]
     },
     {
@@ -68,13 +68,17 @@
         "--freq_norm",
         "rma",
         "--raw_data_path",
-        "s3://scedc-pds/continuous_waveforms/2002/2002_002/",
+        "s3://scedc-pds/continuous_waveforms/",
         "--ccf_path",
         "${userHome}/ccfs3tmp/",
         "--stations",
-        "SBC,RIO,DEV,HEC,RLR,SVD,RPV,BAK",
+        "SBC,RIO,DEV",
         "--xml_path",
-        "s3://scedc-pds/FDSNstationXML/CI/"
+        "s3://scedc-pds/FDSNstationXML/CI/",
+        "--start",
+        "2022_02_02",
+        "--end",
+        "2022_02_05"
       ],
       "console": "integratedTerminal",
       "justMyCode": true

--- a/tests/test_scedc_s3store.py
+++ b/tests/test_scedc_s3store.py
@@ -22,8 +22,9 @@ def test_parsefilename(file: str, expected: DateTimeRange):
 
 
 data_paths = [
-    os.path.join(os.path.dirname(__file__), "./data/s3scedc"),
-    "s3://scedc-pds/continuous_waveforms/2022/2022_002/",
+    (os.path.join(os.path.dirname(__file__), "./data/s3scedc"), None),
+    ("s3://scedc-pds/continuous_waveforms/2022/2022_002/", None),
+    ("s3://scedc-pds/continuous_waveforms/", timespan1),
 ]
 
 
@@ -36,7 +37,8 @@ read_channels = [
 
 @pytest.fixture(params=data_paths)
 def store(request):
-    return SCEDCS3DataStore(request.param, MockCatalog(), lambda ch: ch in read_channels)
+    (path, timespan) = request.param
+    return SCEDCS3DataStore(path, MockCatalog(), lambda ch: ch in read_channels, timespan)
 
 
 @pytest.mark.parametrize("channel", read_channels)

--- a/tutorials/noisepy_scedc_tutorial.ipynb
+++ b/tutorials/noisepy_scedc_tutorial.ipynb
@@ -80,6 +80,8 @@
         "from noisepy.seis.channelcatalog import XMLStationChannelCatalog        # Required stationXML handling object\n",
         "import os\n",
         "import glob\n",
+        "from datetime import datetime\n",
+        "from datetimerange import DateTimeRange\n",
         "\n",
         "\n",
         "# create directory to store data locally\n",
@@ -107,11 +109,13 @@
       },
       "outputs": [],
       "source": [
-        "year = 2002     # year of analysis\n",
-        "doy = 2         # day of year (1-365)\n",
         "# SCEDC S3 bucket common URL characters for that day.\n",
-        "S3_DATA = \"s3://scedc-pds/continuous_waveforms/\"+str(year)+\"/\"+str(year)+\"_\"+str(doy).zfill(3)+\"/\"  # 1 day of data\n",
-        "print(S3_DATA)"
+        "S3_DATA = \"s3://scedc-pds/continuous_waveforms/\"\n",
+        "# timeframe for analysis\n",
+        "start = datetime(2002, 1, 2)\n",
+        "end = datetime(2002, 1, 4)\n",
+        "range = DateTimeRange(start, end)\n",
+        "print(range)"
       ]
     },
     {
@@ -249,23 +253,11 @@
         "\n",
         "stations = \"SBC,RIO,DEV\".split(\",\") # filter to these stations\n",
         "catalog = XMLStationChannelCatalog(S3_STATION_XML)\n",
-        "raw_store = SCEDCS3DataStore(S3_DATA, catalog, channel_filter(stations, \"BH\")) # Store for reading raw data from S3 bucket\n",
+        "raw_store = SCEDCS3DataStore(S3_DATA, catalog, channel_filter(stations, \"BH\"), range) # Store for reading raw data from S3 bucket\n",
         "cc_store = ASDFCCStore(cc_data_path) # Store for writing CC data\n",
         "\n",
         "# print the configuration parameters. Some are chosen by default but we can modify them\n",
         "print(config)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "C4eIzDJtkWks"
-      },
-      "outputs": [],
-      "source": [
-        "ts = raw_store.get_timespans()\n",
-        "raw_store.get_channels(ts[0])"
       ]
     },
     {


### PR DESCRIPTION
- Updated the SCEDCS3Store to take an additional date range parameter
- Update CLI (main.py) to take start/end dates for CC
- Updated unit tests 
- Updated tutorials/noisepy_scedc_tutorial.ipynb to use two days of data 
- Added S3 testing during CI


Tested using MPI over 3 days:

```
mpiexec -n 3 noisepy cross_correlate \
--raw_data_path s3://scedc-pds/continuous_waveforms/ \
--xml_path s3://scedc-pds/FDSNstationXML/CI/ \
 --ccf_path ~/ccfs3tmp --freq_norm rma --stations "SBC,RIO,DEV" \
--start 2022_02_02 --end 2022_02_05
```
