### PR TITLE
Refactor S1 to use a dataclass for FFT data

### DIFF
--- a/src/noisepy/seis/S1_fft_cc_MPI.py
+++ b/src/noisepy/seis/S1_fft_cc_MPI.py
@@ -118,11 +118,12 @@ def cross_correlate(
         tlog.reset()
         for ix_ch, (ch, ch_data) in enumerate(ch_data_tuples):
             # TODO: Below the last values for N and Nfft are used?
-            fft = compute_fft(fft_params, ch_data)
-            ffts[ix_ch] = fft
-            if fft.fft.size == 0:
+            fft_data = compute_fft(fft_params, ch_data)
+            if fft_data.fft.size > 0:
+                ffts[ix_ch] = fft_data
+            else:
                 logger.warning(f"No data available for channel '{ch}', skipped")
-        Nfft = fft.Nfft2 * 2
+        Nfft = fft_data.Nfft2 * 2
         tlog.log("Compute FFTs")
 
         if len(ffts) != nchannels:

--- a/src/noisepy/seis/S1_fft_cc_MPI.py
+++ b/src/noisepy/seis/S1_fft_cc_MPI.py
@@ -123,7 +123,7 @@ def cross_correlate(
                 ffts[ix_ch] = fft_data
             else:
                 logger.warning(f"No data available for channel '{ch}', skipped")
-        Nfft = fft_data.Nfft2 * 2
+        Nfft = fft_data.Length
         tlog.log("Compute FFTs")
 
         if len(ffts) != nchannels:
@@ -143,10 +143,10 @@ def cross_correlate(
                 tlog.reset()
                 # -----------get the smoothed source spectrum for decon later----------
                 sfft1 = noise_module.smooth_source_spect(fft_params, src_fft.fft)
-                sfft1 = sfft1.reshape(src_fft.N, src_fft.Nfft2)
+                sfft1 = sfft1.reshape(src_fft.SegmentCount, src_fft.Length // 2)
                 tlog.log("smoothing source")
             else:
-                sfft1 = np.conj(src_fft.fft).reshape(src_fft.N, src_fft.Nfft2)
+                sfft1 = np.conj(src_fft.fft).reshape(src_fft.SegmentCount, src_fft.Length // 2)
 
             # get index right for auto/cross correlation
             istart = iiS  # start at the channel source / only fills the upper right triangle matrix of channel pairs
@@ -166,7 +166,7 @@ def cross_correlate(
 
                 # read the receiver data
                 rec_fft = ffts[iiR]
-                sfft2 = rec_fft.fft.reshape(rec_fft.N, rec_fft.Nfft2)
+                sfft2 = rec_fft.fft.reshape(rec_fft.SegmentCount, rec_fft.Length // 2)
                 rec_std = rec_fft.std
 
                 # ---------- check the existence of earthquakes or spikes ----------
@@ -249,7 +249,7 @@ def compute_fft(fft_params: ConfigParameters, ch_data: ChannelData) -> NoiseFFT:
     std = trace_stdS
     fft_time = dataS_t
     del trace_stdS, dataS_t, dataS, source_white, data
-    return NoiseFFT(fft, std, fft_time, N, Nfft2)
+    return NoiseFFT(fft, std, fft_time, N, Nfft)
 
 
 def _read_channels(

--- a/src/noisepy/seis/datatypes.py
+++ b/src/noisepy/seis/datatypes.py
@@ -168,5 +168,5 @@ class NoiseFFT:
     fft: np.ndarray
     std: np.ndarray
     fft_time: np.ndarray
-    N: int
-    Nfft2: int
+    SegmentCount: int
+    Length: int

--- a/src/noisepy/seis/datatypes.py
+++ b/src/noisepy/seis/datatypes.py
@@ -157,3 +157,16 @@ class ChannelData:
         self.data = stream[0].data
         self.sampling_rate = stream[0].stats.sampling_rate
         self.start_timestamp = stream[0].stats.starttime.timestamp
+
+
+@dataclass
+class NoiseFFT:
+    """
+    Data class to hold FFT and associated data
+    """
+
+    fft: np.ndarray
+    std: np.ndarray
+    fft_time: np.ndarray
+    N: int
+    Nfft2: int

--- a/src/noisepy/seis/main.py
+++ b/src/noisepy/seis/main.py
@@ -221,6 +221,7 @@ def main_cli():
         [
             lambda p: add_paths(p, ["raw_data", "ccf", "stack"]),
             add_download_args,
+            lambda p: add_date_args(p, True),
             add_cc_args,
             add_stack_args,
             add_stations_arg,


### PR DESCRIPTION
This is a pre-cursor step to parallelizing the cross-correlation computations. The FFTs/STD and other data about a channel are now put in a data structure (`NoiseFFT`) instead of single arrays. This helps in a few ways:

- The array doesn't have 'holes' if some channel doesn't have data, we just don't store an object for this array. This removes the need for the `fft_flag` array.
- There's less indexing, making the code more readable. E.g. `src_fft.std` vs `fft_std[iiS]`
