### PR TITLE
Use CC store in S2

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "request": "launch",
       "module": "pytest",
       "args": [
-        "${workspaceFolder}/tests/test_scedc_s3store.py"
+        "${workspaceFolder}/tests/"
       ]
     },
     {

--- a/src/noisepy/seis/S1_fft_cc_MPI.py
+++ b/src/noisepy/seis/S1_fft_cc_MPI.py
@@ -70,9 +70,10 @@ def cross_correlate(
     tlog = TimeLogger(logger, logging.INFO)
     t_s1_total = tlog.reset()
 
-    context = ray.init()
-    tlog.log("Ray init")
-    print(context.dashboard_url)
+    if not ray.is_initialized():
+        context = ray.init(ignore_reinit_error=True)
+        tlog.log("Ray init")
+        logger.info(context.dashboard_url)
 
     # save metadata
     cc_store.save_parameters(fft_params)

--- a/src/noisepy/seis/S2_stacking.py
+++ b/src/noisepy/seis/S2_stacking.py
@@ -1,9 +1,8 @@
-import glob
 import logging
 import os
 import sys
 import time
-from typing import List
+from typing import Tuple
 
 import numpy as np
 import pandas as pd
@@ -11,6 +10,7 @@ import pyasdf
 from mpi4py import MPI
 
 from noisepy.seis.datatypes import ConfigParameters
+from noisepy.seis.stores import CrossCorrelationDataStore
 
 from . import noise_module
 
@@ -44,10 +44,10 @@ MAX_MEM = 4.0
 
 
 # TODO: make stack_method an enum
-def stack(sta: List[str], ccf_dir: str, stack_dir: str, fft_params: ConfigParameters):
+def stack(cc_store: CrossCorrelationDataStore, stack_dir: str, fft_params: ConfigParameters):
     tt0 = time.time()
     if fft_params.rotation and fft_params.correction:
-        corrfile = os.path.join(ccf_dir, "../meso_angles.txt")  # csv file containing angle info to be corrected
+        corrfile = os.path.join(stack_dir, "../meso_angles.txt")  # csv file containing angle info to be corrected
         locs = pd.read_csv(corrfile)
     else:
         locs = []
@@ -79,120 +79,90 @@ def stack(sta: List[str], ccf_dir: str, stack_dir: str, fft_params: ConfigParame
         fout.write(str(fft_params))
         fout.close()
 
-        # cross-correlation files
-        ccfiles = sorted(glob.glob(os.path.join(ccf_dir, "*.h5")))
-        logger.debug(ccfiles)
+        timespans = cc_store.get_timespans()
+        pairs_all = cc_store.get_station_pairs(timespans[0])
+        stations = set(pair[0] for pair in pairs_all)
 
-        for ii in range(len(sta)):
-            tmp = os.path.join(stack_dir, sta[ii])
-            if not os.path.isdir(tmp):
-                os.mkdir(tmp)
-
-        # station-pairs
-        pairs_all = []
-        for ii in range(len(sta) - 1):
-            for jj in range(ii, len(sta)):
-                pairs_all.append(sta[ii] + "_" + sta[jj])
+        for station in stations:
+            os.makedirs(os.path.join(stack_dir, str(station)), exist_ok=True)
 
         splits = len(pairs_all)
-        if len(ccfiles) == 0 or splits == 0:
+        if len(timespans) == 0 or splits == 0:
             raise IOError("Abort! no available CCF data for stacking")
-
     else:
-        splits, ccfiles, pairs_all = [None for _ in range(3)]
+        splits, timespans, pairs_all = [None for _ in range(3)]
 
     # broadcast the variables
     splits = comm.bcast(splits, root=0)
-    ccfiles = comm.bcast(ccfiles, root=0)
+    timespans = comm.bcast(timespans, root=0)
     pairs_all = comm.bcast(pairs_all, root=0)
+    nccomp = fft_params.ncomp * fft_params.ncomp
+    num_chunk = len(timespans) * nccomp
+    num_segmts = 1
 
     # MPI loop: loop through each user-defined time chunck
     for ipair in range(rank, splits, size):
         t0 = time.time()
 
         logger.debug("%dth path for station-pair %s" % (ipair, pairs_all[ipair]))
-        # source folder
-        ttr = pairs_all[ipair].split("_")
-        snet, ssta = ttr[0].split(".")
-        rnet, rsta = ttr[1].split(".")
-        idir = ttr[0]
+        sta_pair = pairs_all[ipair]
+        src_sta = sta_pair[0]
+        rec_sta = sta_pair[1]
+        idir = str(src_sta)
 
         # check if it is auto-correlation
-        if ssta == rsta and snet == rnet:
+        if src_sta == rec_sta:
             fauto = 1
         else:
             fauto = 0
 
         # continue when file is done: TODO: Remove this and use a Store.contains() function.
-        toutfn = os.path.join(stack_dir, idir + "/" + pairs_all[ipair] + ".tmp")
+        toutfn = os.path.join(stack_dir, idir, f"{src_sta}_{rec_sta}.tmp")
         if os.path.isfile(toutfn):
             continue
 
         # crude estimation on memory needs (assume float32)
-        nccomp = fft_params.ncomp * fft_params.ncomp
-        num_chunck = len(ccfiles) * nccomp
-        num_segmts = 1
-        if fft_params.substack:  # things are difference when do substack
-            if fft_params.substack_len == fft_params.cc_len:
-                num_segmts = int(np.floor((fft_params.inc_hours * 3600 - fft_params.cc_len) / fft_params.step))
-            else:
-                num_segmts = int(fft_params.inc_hours / (fft_params.substack_len / 3600))
-        npts_segmt = int(2 * fft_params.maxlag * fft_params.samp_freq) + 1
-        memory_size = num_chunck * num_segmts * npts_segmt * 4 / 1024**3
-
-        if memory_size > MAX_MEM:
-            raise ValueError(
-                "Require %5.3fG memory but only %5.3fG provided)! Cannot load cc data all once!"
-                % (memory_size, MAX_MEM)
-            )
-        logger.debug("Good on memory (need %5.2f G and %s G provided)!" % (memory_size, MAX_MEM))
+        num_segmts, npts_segmt = calc_segments(fft_params, num_chunk)
         # allocate array to store fft data/info
-        cc_array = np.zeros((num_chunck * num_segmts, npts_segmt), dtype=np.float32)
-        cc_time = np.zeros(num_chunck * num_segmts, dtype=np.float32)
-        cc_ngood = np.zeros(num_chunck * num_segmts, dtype=np.int16)
-        cc_comp = np.chararray(num_chunck * num_segmts, itemsize=2, unicode=True)
+        cc_array = np.zeros((num_chunk * num_segmts, npts_segmt), dtype=np.float32)
+        cc_time = np.zeros(num_chunk * num_segmts, dtype=np.float32)
+        cc_ngood = np.zeros(num_chunk * num_segmts, dtype=np.int16)
+        cc_comp = np.chararray(num_chunk * num_segmts, itemsize=2, unicode=True)
 
         # loop through all time-chuncks
         iseg = 0
-        dtype = pairs_all[ipair]
-        for ifile in ccfiles:
+        for ts in timespans:
             # load the data from daily compilation
-            ds = pyasdf.ASDFDataSet(ifile, mpi=False, mode="r")
-            try:
-                path_list = ds.auxiliary_data[dtype].list()
-                tparameters = ds.auxiliary_data[dtype][path_list[0]].parameters
-            except Exception:
-                logger.debug("continue! no pair of %s in %s" % (dtype, ifile))
-                continue
-            logger.debug(f"path_list for {dtype}: {path_list}")
+            ch_pairs = cc_store.get_channeltype_pairs(ts, src_sta, rec_sta)
+
+            logger.debug(f"path_list for {src_sta}-{rec_sta}: {ch_pairs}")
             # seperate auto and cross-correlation
             if fauto == 1:
-                if fft_params.ncomp == 3 and len(path_list) < 6:
+                if fft_params.ncomp == 3 and len(ch_pairs) < 6:
                     logger.warning(
-                        "continue! not enough cross components for auto-correlation %s in %s" % (dtype, ifile)
+                        "continue! not enough cross components for auto-correlation %s in %s" % (sta_pair, ts)
                     )
                     continue
             else:
-                if fft_params.ncomp == 3 and len(path_list) < 9:
+                if fft_params.ncomp == 3 and len(ch_pairs) < 9:
                     logger.warning(
-                        "continue! not enough cross components for cross-correlation %s in %s" % (dtype, ifile)
+                        "continue! not enough cross components for cross-correlation %s in %s" % (sta_pair, ts)
                     )
                     continue
 
-            if len(path_list) > 9:
-                raise ValueError("more than 9 cross-component exists for %s %s! please double check" % (ifile, dtype))
+            if len(ch_pairs) > 9:
+                raise ValueError("more than 9 cross-component exists for %s %s! please double check" % (ts, sta_pair))
 
             # load the 9-component data, which is in order in the ASDF
-            for tpath in path_list:
-                cmp1 = tpath.split("_")[0]
-                cmp2 = tpath.split("_")[1]
-                tcmp1 = cmp1[-1]
-                tcmp2 = cmp2[-1]
+            for ch_pair in ch_pairs:
+                src_chan, rec_chan = ch_pair
+                tcmp1 = src_chan.get_orientation()
+                tcmp2 = rec_chan.get_orientation()
 
                 # read data and parameter matrix
-                tdata = ds.auxiliary_data[dtype][tpath].data[:]
-                ttime = ds.auxiliary_data[dtype][tpath].parameters["time"]
-                tgood = ds.auxiliary_data[dtype][tpath].parameters["ngood"]
+                tparameters, tdata = cc_store.read(ts, src_sta, rec_sta, src_chan, rec_chan)
+                ttime = tparameters["time"]
+                tgood = tparameters["ngood"]
                 if fft_params.substack:
                     for ii in range(tdata.shape[0]):
                         cc_array[iseg] = tdata[ii]
@@ -213,7 +183,7 @@ def stack(sta: List[str], ccf_dir: str, stack_dir: str, fft_params: ConfigParame
         # continue when there is no data or for auto-correlation
         if iseg <= 1 and fauto == 1:
             continue
-        outfn = pairs_all[ipair] + ".h5"
+        outfn = f"{src_sta}_{rec_sta}.h5"
         logger.debug("ready to output to %s" % (outfn))
 
         # matrix used for rotation
@@ -310,8 +280,8 @@ def stack(sta: List[str], ccf_dir: str, stack_dir: str, fft_params: ConfigParame
         if fft_params.rotation and iflag:
             if np.all(bigstack == 0):
                 continue
-            tparameters["station_source"] = ssta
-            tparameters["station_receiver"] = rsta
+            tparameters["station_source"] = src_sta.name
+            tparameters["station_receiver"] = rec_sta.name
             if fft_params.stack_method != "all":
                 bigstack_rotated = noise_module.rotation(bigstack, tparameters, locs)
 
@@ -369,6 +339,23 @@ def stack(sta: List[str], ccf_dir: str, stack_dir: str, fft_params: ConfigParame
     tt1 = time.time()
     logger.info("it takes %6.2fs to process step 2 in total" % (tt1 - tt0))
     comm.barrier()
+
+
+def calc_segments(fft_params: ConfigParameters, num_chunk: int) -> Tuple[int, int]:
+    if fft_params.substack:  # things are difference when do substack
+        if fft_params.substack_len == fft_params.cc_len:
+            num_segmts = int(np.floor((fft_params.inc_hours * 3600 - fft_params.cc_len) / fft_params.step))
+        else:
+            num_segmts = int(fft_params.inc_hours / (fft_params.substack_len / 3600))
+    npts_segmt = int(2 * fft_params.maxlag * fft_params.samp_freq) + 1
+    memory_size = num_chunk * num_segmts * npts_segmt * 4 / 1024**3
+
+    if memory_size > MAX_MEM:
+        raise ValueError(
+            "Require %5.3fG memory but only %5.3fG provided)! Cannot load cc data all once!" % (memory_size, MAX_MEM)
+        )
+    logger.debug("Good on memory (need %5.2f G and %s G provided)!" % (memory_size, MAX_MEM))
+    return num_segmts, npts_segmt
 
 
 # Point people to new entry point:

--- a/src/noisepy/seis/S2_stacking.py
+++ b/src/noisepy/seis/S2_stacking.py
@@ -80,7 +80,8 @@ def stack(cc_store: CrossCorrelationDataStore, stack_dir: str, fft_params: Confi
         fout.close()
 
         timespans = cc_store.get_timespans()
-        pairs_all = cc_store.get_station_pairs(timespans[0])
+        pairs_all = list(set(pair for ts in timespans for pair in cc_store.get_station_pairs(ts)))
+        logger.info(f"Station pairs: {pairs_all}")
         stations = set(pair[0] for pair in pairs_all)
 
         for station in stations:

--- a/src/noisepy/seis/datatypes.py
+++ b/src/noisepy/seis/datatypes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from enum import Enum
 
@@ -51,6 +52,22 @@ class Station:
     lon: float
     elevation: float
     location: str
+
+    def __init__(
+        self,
+        network: str,
+        name: str,
+        lat: float = sys.float_info.min,
+        lon: float = sys.float_info.min,
+        elevation: float = sys.float_info.min,
+        location: str = "",
+    ):
+        self.network = network
+        self.name = name
+        self.lat = lat
+        self.lon = lon
+        self.elevation = elevation
+        self.location = location
 
     def __repr__(self) -> str:
         return f"{self.network}.{self.name}"

--- a/src/noisepy/seis/main.py
+++ b/src/noisepy/seis/main.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 import typing
 from enum import Enum
@@ -102,6 +103,8 @@ def create_raw_store(args):
 
 def main(args: typing.Any):
     raw_dir = args.raw_data_path
+    logger = logging.getLogger(__package__)
+    logger.setLevel(args.loglevel.upper())
 
     def run_cross_correlation():
         ccf_dir = args.ccf_path
@@ -214,6 +217,13 @@ def make_step_parser(subparsers: Any, step: Step, parser_config_funcs: List[Call
     )
     for config_fn in parser_config_funcs:
         config_fn(parser)
+    parser.add_argument(
+        "-log",
+        "--loglevel",
+        type=str.lower,
+        default="info",
+        choices=["notset", "debug", "info", "warning", "error", "critical"],
+    )
 
 
 def main_cli():

--- a/src/noisepy/seis/main.py
+++ b/src/noisepy/seis/main.py
@@ -121,8 +121,8 @@ def main(args: typing.Any):
     def run_stack():
         params = initialize_stack_params(args.ccf_path)
         params.stack_method = args.method
-        raw_store = create_raw_store(args)
-        stack(raw_store.get_station_list(), args.ccf_path, args.stack_path, params)
+        cc_store = ASDFCCStore(args.ccf_path, "r")
+        stack(cc_store, args.stack_path, params)
 
     if args.step == Step.DOWNLOAD:
         run_download()

--- a/src/noisepy/seis/scedc_s3store.py
+++ b/src/noisepy/seis/scedc_s3store.py
@@ -139,5 +139,5 @@ class SCEDCS3DataStore(RawDataStore):
         return Channel(
             ChannelType(channel, location),
             # lat/lon/elev will be populated later
-            Station(network, station, -1, -1, -1, location),
+            Station(network, station, location=location),
         )

--- a/src/noisepy/seis/stores.py
+++ b/src/noisepy/seis/stores.py
@@ -1,27 +1,17 @@
 from abc import ABC, abstractmethod
-from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 import obspy
 from datetimerange import DateTimeRange
 
-from .datatypes import Channel, ChannelData, ConfigParameters, Station
+from .datatypes import Channel, ChannelData, ChannelType, ConfigParameters, Station
 
 
 class DataStore(ABC):
     """
     A base abstraction over a data source for seismic data
     """
-
-    # TODO: Are these needed or is get_channels() enough?
-    # @abstractmethod
-    # def get_stations(self) -> List[Station]:
-    #     pass
-
-    # @abstractmethod
-    # def get_channel_types(self) -> List[ChannelType]:
-    #     pass
 
     @abstractmethod
     def get_channels(self, timespan: DateTimeRange) -> List[Channel]:
@@ -88,5 +78,21 @@ class CrossCorrelationDataStore:
         pass
 
     @abstractmethod
-    def read(self, chan1: Channel, chan2: Channel, start: datetime, end: datetime) -> np.ndarray:
+    def get_timespans(self) -> List[DateTimeRange]:
+        pass
+
+    @abstractmethod
+    def get_station_pairs(self, timespan: DateTimeRange) -> List[Tuple[Station, Station]]:
+        pass
+
+    @abstractmethod
+    def get_channeltype_pairs(
+        self, timespan: DateTimeRange, src_sta: Station, rec_sta: Station
+    ) -> List[Tuple[ChannelType, ChannelType]]:
+        pass
+
+    @abstractmethod
+    def read(
+        self, timespan: DateTimeRange, src_sta: Station, rec_sta: Station, src_ch: ChannelType, rec_ch: ChannelType
+    ) -> Tuple[Dict, np.ndarray]:
         pass

--- a/tests/test_channelcatalog.py
+++ b/tests/test_channelcatalog.py
@@ -22,7 +22,7 @@ file = os.path.join(os.path.dirname(__file__), "./data/station.txt")
 @pytest.mark.parametrize("stat,ch,lat,lon,elev", chan_data)
 def test_csv(stat: str, ch: str, lat: float, lon: float, elev: float):
     cat = CSVChannelCatalog(file)
-    chan = Channel(ChannelType(ch), Station("CI", stat, -1, -1, -1, -1))
+    chan = Channel(ChannelType(ch), Station("CI", stat))
     full_ch = cat.get_full_channel(DateTimeRange(), chan)
     assert full_ch.station.lat == lat
     assert full_ch.station.lon == lon
@@ -54,7 +54,7 @@ def test_frominventory(station: str, ch: str, lat: float, lon: float, elev: floa
 
     inv = stats2inv_mseed(stat, df)
     cat = MockCatalog()
-    chan = Channel(ChannelType(ch), Station("CI", station, -1, -1, -1, -1))
+    chan = Channel(ChannelType(ch), Station("CI", station))
     full_ch = cat.populate_from_inventory(inv, chan)
     assert full_ch.station.lat == lat
     assert full_ch.station.lon == lon
@@ -67,8 +67,8 @@ xmlpaths = [os.path.join(os.path.dirname(__file__), "./data/"), "s3://scedc-pds/
 @pytest.mark.parametrize("path", xmlpaths)
 def test_XMLStationChannelCatalog(path):
     cat = XMLStationChannelCatalog(path)
-    empty_inv = cat.get_inventory(DateTimeRange(), Station("non-existent", "non-existent", 0, 0, 0, ""))
+    empty_inv = cat.get_inventory(DateTimeRange(), Station("non-existent", "non-existent", ""))
     assert len(empty_inv) == 0
-    yaq_inv = cat.get_inventory(DateTimeRange(), Station("CI", "YAQ", 0, 0, 0, ""))
+    yaq_inv = cat.get_inventory(DateTimeRange(), Station("CI", "YAQ"))
     assert len(yaq_inv) == 1
     assert len(yaq_inv.networks[0].stations) == 1

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -1,8 +1,10 @@
 RUNNER_TEMP=~/test_temp
+LOG_LEVEL=debug
 rm -rf $RUNNER_TEMP
-noisepy download --start 2019_02_01_00_00_00 --end 2019_02_01_01_00_00 --stations ARV,BAK --inc_hours 1 --raw_data_path $RUNNER_TEMP/RAW_DATA
-noisepy cross_correlate --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --freq_norm rma
-noisepy stack --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --method linear
+noisepy download --start 2019_02_01_00_00_00 --end 2019_02_01_01_00_00 --stations ARV,BAK --inc_hours 1 --raw_data_path $RUNNER_TEMP/RAW_DATA --log ${LOG_LEVEL}
+noisepy cross_correlate --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --freq_norm rma --log ${LOG_LEVEL}
+rm -rf $RUNNER_TEMP/STACK
+noisepy stack --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --method linear --log ${LOG_LEVEL}
 rm -rf $RUNNER_TEMP
 noisepy all --start 2019_02_01_00_00_00 --end 2019_02_01_01_00_00 --stations ARV,BAK --inc_hours 1 --raw_data_path $RUNNER_TEMP/RAW_DATA \
-       --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --method linear --freq_norm rma
+       --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --method linear --freq_norm rma --log ${LOG_LEVEL}

--- a/tests/test_cross_correlation.py
+++ b/tests/test_cross_correlation.py
@@ -13,7 +13,7 @@ def test_read_channels():
         cd.sampling_rate = f
         ch_data.append(cd)
     N = 5
-    tuples = [(Channel("foo", Station("CI", "bar", 0, 0, 0, "")), cd) for cd in ch_data] * N
+    tuples = [(Channel("foo", Station("CI", "bar")), cd) for cd in ch_data] * N
     filtered = _filter_channel_data(tuples, samp_freq)
     assert N == len(filtered)
     assert [t[1].sampling_rate for t in filtered] == [CLOSEST_FREQ] * N

--- a/tests/test_scedc_s3store.py
+++ b/tests/test_scedc_s3store.py
@@ -68,8 +68,8 @@ def test_get_station_list(store: SCEDCS3DataStore):
 def test_filter():
     # filter for station 'staX' or 'staY' and channel type starts with 'B'
     f = channel_filter(["staX", "staY"], "B")
-    staX = Station("CI", "staX", 0, 0, 0, "")
-    staZ = Station("CI", "staZ", 0, 0, 0, "")
+    staX = Station("CI", "staX")
+    staZ = Station("CI", "staZ")
 
     def check(sta, ch_name):
         ch = Channel(ChannelType((ch_name)), sta)

--- a/tutorials/get_started.ipynb
+++ b/tutorials/get_started.ipynb
@@ -318,7 +318,7 @@
    },
    "outputs": [],
    "source": [
-    "stack(cc_store, stack_data_path, \"linear\")"
+    "stack(cc_store, stack_data_path, config)"
    ]
   },
   {
@@ -354,13 +354,6 @@
     "print(files)\n",
     "plotting_modules.plot_all_moveout(files, 'Allstack_linear', 0.1, 0.2, 'ZZ', 1)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/get_started.ipynb
+++ b/tutorials/get_started.ipynb
@@ -318,9 +318,7 @@
    },
    "outputs": [],
    "source": [
-    "stations = raw_store.get_station_list()\n",
-    "print(stations)\n",
-    "stack(stations, cc_data_path, stack_data_path, \"linear\")"
+    "stack(cc_store, stack_data_path, \"linear\")"
    ]
   },
   {


### PR DESCRIPTION
Changes

- Similar to the change made in S1, S2 no uses the CrossCorrelationDataStore instead of directly accessing the ASDF files.
- Refactored ASDF stores to share functionality between the raw and CC stores
- Add unit tests for the new reading functions in the CC store
- Add a constructor for `Station` to use when lat/lon/elev are not known. Previously `0` and `-1` were inconsistently used as missing values, neither of which was good.
- Fix problem with double initialization of ray.

TODO: Implement a similar store for writing the stacked data