### PR TITLE
Refactoring of ASDF stores

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,6 +38,25 @@
       "justMyCode": true
     },
     {
+      "name": "Python: CC ASDF",
+      "type": "python",
+      "request": "launch",
+      "module": "noisepy.seis.main",
+      "args": [
+        "cross_correlate",
+        "--freq_norm",
+        "rma",
+        "--raw_data_path",
+        "${userHome}/test_temp/RAW_DATA",
+        "--ccf_path",
+        "${userHome}/test_temp/CCF",
+        "--stations",
+        "SBC,RIO,DEV,HEC,RLR,SVD,RPV,BAK"
+      ],
+      "console": "integratedTerminal",
+      "justMyCode": true
+    },
+    {
       "name": "Python: cross_correlate",
       "type": "python",
       "request": "launch",

--- a/src/noisepy/seis/S1_fft_cc_MPI.py
+++ b/src/noisepy/seis/S1_fft_cc_MPI.py
@@ -148,7 +148,7 @@ def cross_correlate(
             results = ray.get(ready)
             results = [r for subresult in results for r in subresult]
             for src_chan, rec_chan, parameters, corr in results:
-                cc_store.append(ts, src_chan, rec_chan, fft_params, parameters, corr)
+                cc_store.append(ts, src_chan, rec_chan, parameters, corr)
 
         ffts.clear()
         gc.collect()

--- a/tests/test_asdfstore.py
+++ b/tests/test_asdfstore.py
@@ -6,7 +6,7 @@ import pytest
 from datetimerange import DateTimeRange
 
 from noisepy.seis.asdfstore import ASDFCCStore, ASDFRawDataStore
-from noisepy.seis.datatypes import Channel, ChannelType, ConfigParameters, Station
+from noisepy.seis.datatypes import Channel, ChannelType, Station
 
 
 @pytest.fixture
@@ -52,7 +52,6 @@ def test_ccstore(ccstore: ASDFCCStore):
         dt = dt.replace(tzinfo=timezone.utc, microsecond=0)
         return DateTimeRange(dt, dt + timedelta(days=1))
 
-    config = ConfigParameters()
     data = np.zeros(0)
     ts1 = make_1dts(datetime.now())
     ts2 = make_1dts(ts1.end_datetime)
@@ -62,16 +61,16 @@ def test_ccstore(ccstore: ASDFCCStore):
     # assert empty state
     assert not ccstore.is_done(ts1)
     assert not ccstore.is_done(ts2)
-    assert not ccstore.contains(ts1, src, rec, config)
-    assert not ccstore.contains(ts2, src, rec, config)
+    assert not ccstore.contains(ts1, src, rec)
+    assert not ccstore.contains(ts2, src, rec)
 
     # add CC (src->rec) for ts1
-    ccstore.append(ts1, src, rec, config, {}, data)
+    ccstore.append(ts1, src, rec, {}, data)
     # assert ts1 is there, but not ts2
-    assert ccstore.contains(ts1, src, rec, config)
-    assert not ccstore.contains(ts2, src, rec, config)
+    assert ccstore.contains(ts1, src, rec)
+    assert not ccstore.contains(ts2, src, rec)
     # also rec->src should not be there for ts1
-    assert not ccstore.contains(ts1, rec, src, config)
+    assert not ccstore.contains(ts1, rec, src)
     assert not ccstore.is_done(ts1)
     # now mark ts1 done and assert it
     ccstore.mark_done(ts1)
@@ -79,8 +78,8 @@ def test_ccstore(ccstore: ASDFCCStore):
     assert not ccstore.is_done(ts2)
 
     # now add CC for ts2
-    ccstore.append(ts2, src, rec, config, {}, data)
-    assert ccstore.contains(ts2, src, rec, config)
+    ccstore.append(ts2, src, rec, {}, data)
+    assert ccstore.contains(ts2, src, rec)
     assert not ccstore.is_done(ts2)
     ccstore.mark_done(ts2)
     assert ccstore.is_done(ts2)

--- a/tests/test_scedc_s3store.py
+++ b/tests/test_scedc_s3store.py
@@ -60,11 +60,6 @@ def test_timespan_channels(store: SCEDCS3DataStore):
     assert len(channels) == 0
 
 
-def test_get_station_list(store: SCEDCS3DataStore):
-    stations = store.get_station_list()
-    assert stations == ["BK.THIS", "CI.FOX2", "CI.NCH"]
-
-
 def test_filter():
     # filter for station 'staX' or 'staY' and channel type starts with 'B'
     f = channel_filter(["staX", "staY"], "B")

--- a/tutorials/noisepy_scedc_tutorial.ipynb
+++ b/tutorials/noisepy_scedc_tutorial.ipynb
@@ -310,9 +310,7 @@
       },
       "outputs": [],
       "source": [
-        "stations = raw_store.get_station_list()\n",
-        "print(stations)\n",
-        "stack(stations, cc_data_path, stack_data_path, \"linear\")"
+        "stack(cc_store, stack_data_path, config)"
       ]
     },
     {
@@ -383,7 +381,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.8.16"
+      "version": "3.10.11"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
This is a refactoring in preparation for writing an ASDFStackStore. This will have very similar functionality to the other ASDF stores, except that the files are names after pairs of stations (e.g. `CI.AVM_CI.AVM.h5`) vs time ranges (`2019_02_01_00_00_00T2019_02_01_12_00_00.h5`). The core part of the refactoring is moving the common functionality up to the `ASDFDirectory` helper class.