### PR TITLE
Support custom file names in XMLStationChannelCatalog

### DIFF
--- a/src/noisepy/seis/S1_fft_cc_MPI.py
+++ b/src/noisepy/seis/S1_fft_cc_MPI.py
@@ -14,7 +14,7 @@ from noisepy.seis.datatypes import Channel, ChannelData, ConfigParameters, Noise
 
 from . import noise_module
 from .stores import CrossCorrelationDataStore, RawDataStore
-from .utils import TimeLogger
+from .utils import TimeLogger, error_if
 
 logger = logging.getLogger(__name__)
 # ignore warnings
@@ -88,6 +88,11 @@ def cross_correlate(
 
         t_chunk = tlog.reset()  # for tracking overall chunk processing time
         all_channels = raw_store.get_channels(ts)
+        error_if(
+            not all(map(lambda c: c.station.valid(), all_channels)),
+            "The stations don't have their lat/lon/elev properties populated. Problem with the ChannelCatalog used?",
+        )
+
         tlog.log("get channels")
         ch_data_tuples = _read_channels(executor, ts, raw_store, all_channels, fft_params.samp_freq)
         # only the channels we are using

--- a/src/noisepy/seis/channelcatalog.py
+++ b/src/noisepy/seis/channelcatalog.py
@@ -57,15 +57,25 @@ class XMLStationChannelCatalog(ChannelCatalog):
     A channel catalog that reads <station>.XML files from a directory or an s3://... bucket url path.
     """
 
-    def __init__(self, xmlpath: str) -> None:
+    def __init__(self, xmlpath: str, path_format: str = "{network}_{name}.xml") -> None:
+        """
+        Constructs a XMLStationChannelCatalog
+
+        Args:
+            xmlpath (str): Base directory where to find the files
+            path_format (str): Format string to construct the file name from a station.
+                               The argument names are 'network' and 'name'.
+        """
         super().__init__()
         self.xmlpath = xmlpath
+        self.path_format = path_format
         self.fs = get_filesystem(xmlpath)
         if not self.fs.exists(self.xmlpath):
             raise Exception(f"The XML Station file directory '{xmlpath}' doesn't exist")
 
     def get_inventory(self, timespan: DateTimeRange, station: Station) -> obspy.Inventory:
-        xmlfile = fs_join(self.xmlpath, f"{station.network}_{station.name}.xml")
+        file_name = self.path_format.format(network=station.network, name=station.name)
+        xmlfile = fs_join(self.xmlpath, file_name)
         return self._get_inventory_from_file(xmlfile)
 
     @lru_cache

--- a/src/noisepy/seis/datatypes.py
+++ b/src/noisepy/seis/datatypes.py
@@ -10,6 +10,8 @@ import obspy
 from pydantic import Field, root_validator
 from pydantic_yaml import YamlModel
 
+INVALID_COORD = -sys.float_info.max
+
 
 @dataclass
 class ChannelType:
@@ -60,9 +62,9 @@ class Station:
         self,
         network: str,
         name: str,
-        lat: float = sys.float_info.min,
-        lon: float = sys.float_info.min,
-        elevation: float = sys.float_info.min,
+        lat: float = INVALID_COORD,
+        lon: float = INVALID_COORD,
+        elevation: float = INVALID_COORD,
         location: str = "",
     ):
         self.network = network
@@ -71,6 +73,9 @@ class Station:
         self.lon = lon
         self.elevation = elevation
         self.location = location
+
+    def valid(self) -> bool:
+        return min(self.lat, self.lon, self.elevation) > INVALID_COORD
 
     def __repr__(self) -> str:
         return f"{self.network}.{self.name}"

--- a/src/noisepy/seis/utils.py
+++ b/src/noisepy/seis/utils.py
@@ -73,3 +73,16 @@ class TimeLogger:
         if self.enabled:
             self.logger.log(self.level, f"TIMING: {dt:6.4f} for {message}")
         return self.time
+
+
+def error_if(condition: bool, msg: str, error_type: type = RuntimeError):
+    """
+    Raise an error if the condition is True
+
+    Args:
+        condition (bool): Condition to evaluate
+        msg (str): Error message
+        error_type (type): Type of error to raise, e.g. ValueError
+    """
+    if condition:
+        raise error_type(msg)

--- a/tests/data/CI/CI.YAQ.xml
+++ b/tests/data/CI/CI.YAQ.xml
@@ -1,0 +1,69 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<fsx:FDSNStationXML xmlns:fsx="http://www.fdsn.org/xml/station/1" xmlns:sis="http://anss-sis.scsn.org/xml/ext-stationxml/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xsi:schemaLocation="http://www.fdsn.org/xml/station/1 http://www.fdsn.org/xml/station/fdsn-station-1.1.xsd">
+  <fsx:Source>ANSS Station Information System</fsx:Source>
+  <fsx:Sender>ANSS Station Information System</fsx:Sender>
+  <fsx:Created>2015-10-21T17:51:40.481255Z</fsx:Created>
+  <fsx:Network code="CI">
+    <fsx:Description>Southern California Seismic Network</fsx:Description>
+    <fsx:TotalNumberStations>725</fsx:TotalNumberStations>
+    <fsx:SelectedNumberStations>1</fsx:SelectedNumberStations>
+    <fsx:Station code="YAQ" startDate="1981-04-04T00:00:00Z" endDate="1998-02-02T00:00:00Z">
+      <fsx:Latitude>33.166610</fsx:Latitude>
+      <fsx:Longitude>-116.353860</fsx:Longitude>
+      <fsx:Elevation>430.0</fsx:Elevation>
+      <fsx:Site>
+        <fsx:Name>YAQUI MEADOWS</fsx:Name>
+      </fsx:Site>
+      <fsx:Operator>
+        <fsx:Agency>SCSN-CA</fsx:Agency>
+      </fsx:Operator>
+      <fsx:CreationDate>1981-04-04T00:00:00Z</fsx:CreationDate>
+      <fsx:TotalNumberChannels>1</fsx:TotalNumberChannels>
+      <fsx:SelectedNumberChannels>1</fsx:SelectedNumberChannels>
+      <fsx:Channel code="EHZ" startDate="1981-04-04T00:00:00Z" endDate="1998-02-02T00:00:00Z" locationCode="">
+        <fsx:Comment>
+          <fsx:Value>Historical epoch</fsx:Value>
+          <fsx:BeginEffectiveTime>1981-04-04T00:00:00Z</fsx:BeginEffectiveTime>
+          <fsx:EndEffectiveTime>1998-02-02T00:00:00Z</fsx:EndEffectiveTime>
+          <fsx:Author>
+            <fsx:Name>sis2.0_migration-SCSN LEGACY DB-SIS</fsx:Name>
+          </fsx:Author>
+        </fsx:Comment>
+        <fsx:Latitude>33.166610</fsx:Latitude>
+        <fsx:Longitude>-116.353860</fsx:Longitude>
+        <fsx:Elevation>430.0</fsx:Elevation>
+        <fsx:Depth>0.0</fsx:Depth>
+        <fsx:Azimuth>0.0</fsx:Azimuth>
+        <fsx:Dip>-90.0</fsx:Dip>
+        <fsx:Type>GEOPHYSICAL</fsx:Type>
+        <fsx:SampleRate>9.990000000000E+02</fsx:SampleRate>
+
+        <fsx:CalibrationUnits>
+          <fsx:Name>A</fsx:Name>
+          <fsx:Description>Electric Current in Amperes</fsx:Description>
+        </fsx:CalibrationUnits>
+        <fsx:Sensor>
+          <fsx:Type>UNKNOWN:UNKNOWN_VEL:YAQ_EHZ</fsx:Type>
+          <fsx:Manufacturer>UNKNOWN</fsx:Manufacturer>
+          <fsx:Model>UNKNOWN_VEL</fsx:Model>
+          <fsx:SerialNumber>YAQ_EHZ</fsx:SerialNumber>
+          <fsx:CalibrationDate>1981-04-04T00:00:00Z</fsx:CalibrationDate>
+        </fsx:Sensor>
+        <fsx:Response>
+          <fsx:InstrumentSensitivity>
+            <fsx:Value>1.000000000000E+00</fsx:Value>
+            <fsx:Frequency>1.000000000000E+00</fsx:Frequency>
+            <fsx:InputUnits>
+              <fsx:Name>m/s</fsx:Name>
+              <fsx:Description>Velocity in meters per second</fsx:Description>
+            </fsx:InputUnits>
+            <fsx:OutputUnits>
+              <fsx:Name>V</fsx:Name>
+              <fsx:Description>Voltage in Volts</fsx:Description>
+            </fsx:OutputUnits>
+          </fsx:InstrumentSensitivity>
+        </fsx:Response>
+      </fsx:Channel>
+    </fsx:Station>
+  </fsx:Network>
+</fsx:FDSNStationXML>

--- a/tests/test_channelcatalog.py
+++ b/tests/test_channelcatalog.py
@@ -72,3 +72,11 @@ def test_XMLStationChannelCatalog(path):
     yaq_inv = cat.get_inventory(DateTimeRange(), Station("CI", "YAQ"))
     assert len(yaq_inv) == 1
     assert len(yaq_inv.networks[0].stations) == 1
+
+
+def test_XMLStationChannelCatalogCustomPath():
+    # Check that a custom file name is also found properly, e.g. CI/CI.YAQ.xml
+    cat = XMLStationChannelCatalog(xmlpaths[0], "{network}" + os.path.sep + "{network}.{name}.xml")
+    yaq_inv = cat.get_inventory(DateTimeRange(), Station("CI", "YAQ"))
+    assert len(yaq_inv) == 1
+    assert len(yaq_inv.networks[0].stations) == 1

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from noisepy.seis.datatypes import ChannelType, ConfigParameters, StackMethod
+from noisepy.seis.datatypes import ChannelType, ConfigParameters, StackMethod, Station
 
 
 def test_channeltype():
@@ -25,3 +25,12 @@ def test_config_yaml(tmp_path: Path):
     c1.save_yaml(file)
     c2 = ConfigParameters.parse_file(file)
     assert c1 == c2
+
+
+def test_station_valid():
+    s = Station("CI", "BAK")
+    assert not s.valid()
+    s = Station("CI", "BAK", 110.0, 120.1, 15.0)
+    assert s.valid()
+    s = Station("CI", "BAK", -110.0, 120.1, 15.0)
+    assert s.valid()


### PR DESCRIPTION
- Allow for passing a custom format string to build a file name from a `Station`
- In S1, abort if the stations do not have lat/lon/elevation information
- Added unit tests