### PR TITLE
Optimize download step

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           cd tutorials
           pip install -r requirements.txt
-          jb build .
+          jb build . -W
           cd ..
       - name: Setup Pages
         if: github.event_name == 'push'

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -46,20 +46,20 @@ jobs:
           cd ..
       - name: Publish as artifact
         uses: actions/upload-artifact@v3
-        if: github.event_name == 'pull_request' or steps.build.outcome == 'failure'
+        if: github.event_name == 'pull_request' || steps.build.outcome == 'failure'
         with:
           path: './tutorials/_build/html'
       - name: Setup Pages
-        if: github.event_name == 'push' and steps.build.outcome == 'success'
+        if: github.event_name == 'push' && steps.build.outcome == 'success'
         uses: actions/configure-pages@v3
       - name: Upload pages artifact
-        if: github.event_name == 'push' and steps.build.outcome == 'success'
+        if: github.event_name == 'push' && steps.build.outcome == 'success'
         uses: actions/upload-pages-artifact@v1
         with:
           # Upload html output
           path: './tutorials/_build/html'
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push' and steps.build.outcome == 'success'
+        if: github.event_name == 'push' && steps.build.outcome == 'success'
         id: deployment
         uses: actions/deploy-pages@v2
       - name: Job failed

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -37,26 +37,33 @@ jobs:
         with:
           python-version: "3.10"
       - name: Build pages
+        id: build
+        continue-on-error: true
         run: |
           cd tutorials
           pip install -r requirements.txt
           jb build . -W
           cd ..
+      - name: Publish as artifact
+        uses: actions/upload-artifact@v3
+        if: github.event_name == 'pull_request' or steps.build.outcome == 'failure'
+        with:
+          path: './tutorials/_build/html'
       - name: Setup Pages
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' and steps.build.outcome == 'success'
         uses: actions/configure-pages@v3
-      - name: Upload artifact
-        if: github.event_name == 'push'
+      - name: Upload pages artifact
+        if: github.event_name == 'push' and steps.build.outcome == 'success'
         uses: actions/upload-pages-artifact@v1
         with:
           # Upload html output
           path: './tutorials/_build/html'
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' and steps.build.outcome == 'success'
         id: deployment
         uses: actions/deploy-pages@v2
-      - name: Publish as artifact
-        uses: actions/upload-artifact@v3
-        if: github.event_name == 'pull_request'
-        with:
-          path: './tutorials/_build/html'
+      - name: Job failed
+        if: steps.build.outcome != 'success'
+        run: |
+          echo Build step outcome: ${{steps.build.outcome}}
+          exit 1

--- a/src/noisepy/seis/S2_stacking.py
+++ b/src/noisepy/seis/S2_stacking.py
@@ -165,9 +165,9 @@ def stack(cc_store: CrossCorrelationDataStore, stack_store: StackStore, fft_para
             bigstack1 = np.zeros(shape=(9, npts_segmt), dtype=np.float32)
             bigstack2 = np.zeros(shape=(9, npts_segmt), dtype=np.float32)
 
-        def write_stacks(comp: str, tparameters: Dict[str, Any], stacks: List[Tuple[str, np.ndarray]]):
-            for name, data in stacks:
-                stack_store.append(src_sta, rec_sta, comp, f"Allstack_{name}", tparameters, data)
+        def write_stacks(comp: str, tparameters: Dict[str, Any], stacks: List[Tuple[StackMethod, np.ndarray]]):
+            for method, data in stacks:
+                stack_store.append(src_sta, rec_sta, comp, f"Allstack_{method.value}", tparameters, data)
 
         # loop through cross-component for stacking
         iflag = 1


### PR DESCRIPTION
Changes:

- Use ThreadPoolExecutor to parallelize without MPI
- Use a single call to `client.get_stations_bulk()` to fetch the inventory instead of 1 call per station/channel
- Don't re-fetch the inventory for each station during download, instead reuse the main inventory downloaded at the beginning

## 3 test runs
### Before
```
2023-06-12 16:08:37,095 INFO S0A_download_ASDF_MPI.download(): downloading step takes 120.01 s
2023-06-12 16:12:03,734 INFO S0A_download_ASDF_MPI.download(): downloading step takes 128.84 s
2023-06-12 16:15:23,021 INFO S0A_download_ASDF_MPI.download(): downloading step takes 127.60 s
```
### After
```
2023-06-12 16:19:12,375 DEBUG utils.log(): TIMING: 13.6195 for Total Download
2023-06-12 16:19:34,644 DEBUG utils.log(): TIMING: 10.7182 for Total Download
2023-06-12 16:19:57,185 DEBUG utils.log(): TIMING: 10.4578 for Total Download
```