### PR TITLE
Make MPI an optional dependency

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -4,6 +4,10 @@ inputs:
   python-version:
     required: true
     description: Python version to install
+  mpi:
+    required: false
+    description: Whether to install with MPI or not
+    default: 'false'
 runs:
   using: composite
   steps:
@@ -11,11 +15,19 @@ runs:
       uses: actions/setup-python@v4.5.0
       with:
         python-version: ${{inputs.python-version}}
-    - name: Setup MPI
-      uses: mpi4py/setup-mpi@v1
-    - name: Install project
+    - name: Setup pip
       shell: sh
       run: |
         python3 -m ensurepip
         pip3 install --upgrade pip
-        pip install ".[dev]"
+    - name: Setup MPI
+      if: ${{ inputs.mpi == 'true' }}
+      uses: mpi4py/setup-mpi@v1
+    - name: Install project no MPI
+      if: ${{ inputs.mpi == 'false' }}
+      shell: sh
+      run: pip install ".[dev]"
+    - name: Install project MPI
+      if: ${{ inputs.mpi == 'true' }}
+      shell: sh
+      run: pip install ".[dev,mpi]"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
         python-version: ${{env.python_version}}
     - name: Test Download (S0)
       working-directory: ./src
-      run: noisepy download --start_date 2019-02-01T00:00:00 --end_date 2019-02-01T01:00:00 --stations ARV,BAK --inc_hours 1 --raw_data_path $RUNNER_TEMP/RAW_DATA
+      run: noisepy download --start_date 2019-02-01T00:00:00 --end_date 2019-02-01T02:00:00 --stations ARV,BAK --inc_hours 1 --raw_data_path $RUNNER_TEMP/RAW_DATA
     - name: Cache data
       uses: actions/cache/save@v3
       with:
@@ -99,7 +99,7 @@ jobs:
     - name: Test Cross-Correlation (S1)
       working-directory: ./src
       run: |
-        noisepy cross_correlate --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --freq_norm ${{matrix.freq_norm}}
+        mpiexec -n 2 noisepy cross_correlate --mpi --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --freq_norm ${{matrix.freq_norm}}
     - name: Test Stacking (S2)
       working-directory: ./src
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,6 +70,40 @@ jobs:
       working-directory: ./src
       run: |
         noisepy stack --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method ${{matrix.method}}
+  s1_s2_mpi:
+    strategy:
+      fail-fast: true
+      matrix:
+        python_version: ['3.10']
+        method: [linear]
+        freq_norm: [rma]
+    runs-on: ubuntu-22.04
+    needs: s0_download
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3.3.0
+    - name: Setup NoisePy
+      uses: ./.github/actions/setup
+      with:
+        python-version: ${{matrix.python_version}}
+        mpi: 'true'
+    - name: Cache data
+      id: cache
+      uses: actions/cache/restore@v3
+      with:
+        key: download_data-${{ github.sha }}
+        path: ${{runner.temp}}
+    - name: Check cache hit
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: exit 1
+    - name: Test Cross-Correlation (S1)
+      working-directory: ./src
+      run: |
+        noisepy cross_correlate --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --freq_norm ${{matrix.freq_norm}}
+    - name: Test Stacking (S2)
+      working-directory: ./src
+      run: |
+        mpiexec -n 3 noisepy stack --mpi --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method ${{matrix.method}}
   s3_dates:
     strategy:
       fail-fast: true

--- a/README.md
+++ b/README.md
@@ -23,11 +23,24 @@ The nature of NoisePy being composed of python scripts allows flexible package i
 ```bash
 conda create -n noisepy python=3.8 pip
 conda activate noisepy
-conda install -c conda-forge openmpi
 pip install noisepy-seis
 ```
 
+## With Conda and pip and MPI support:
+```bash
+conda create -n noisepy python=3.8 pip
+conda activate noisepy
+conda install -c conda-forge openmpi
+pip install noisepy-seis[mpi]
+```
+
 ## With virtual environment:
+```bash
+python -m venv noisepy
+source noisepy/bin/activate
+pip install noisepy-seis
+```
+## With virtual environment and MPI support:
 An MPI installation is required. E.g. for macOS using [brew](https://brew.sh/) :
 ```bash
 brew install open-mpi
@@ -36,7 +49,7 @@ brew install open-mpi
 ```bash
 python -m venv noisepy
 source noisepy/bin/activate
-pip install noisepy-seis
+pip install noisepy-seis[mpi]
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ classifiers = [
 dependencies = [
     "DateTimeRange==2.0.0",
     "h5py>=3.8.0",
-    "mpi4py>=3.1.4",
     "numba>=0.57.0",
     "numpy>=1.22.0",
     "pandas>=1.5.3",
@@ -78,6 +77,9 @@ dev = [
 ]
 sql = [
     "SQLite3-0611",
+]
+mpi = [
+    "mpi4py>=3.1.4",
 ]
 
 [project.scripts]

--- a/src/noisepy/seis/S0A_download_ASDF_MPI.py
+++ b/src/noisepy/seis/S0A_download_ASDF_MPI.py
@@ -292,6 +292,7 @@ def download_stream(
             )
         except Exception as e:
             logger.warning(f"{e} for get_waveforms({sta}.{chan})")
+            continue
 
         logger.debug(f"Got waveforms for {sta}.{chan}")
 

--- a/src/noisepy/seis/main.py
+++ b/src/noisepy/seis/main.py
@@ -157,7 +157,8 @@ def main(args: typing.Any):
         cc_store = ASDFCCStore(ccf_dir)
         params = initialize_params(args, args.raw_data_path)
         raw_store = create_raw_store(args, params)
-        cross_correlate(raw_store, params, cc_store)
+        scheduler = MPIScheduler(0) if args.mpi else SingleNodeScheduler()
+        cross_correlate(raw_store, params, cc_store, scheduler)
         params.save_yaml(fs_join(ccf_dir, CONFIG_FILE))
 
     def run_stack():
@@ -227,7 +228,7 @@ def parse_args(arguments: Iterable[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="cmd", required=True)
     make_step_parser(subparsers, Command.DOWNLOAD, ["raw_data"])
-    make_step_parser(subparsers, Command.CROSS_CORRELATE, ["raw_data", "ccf", "xml"])
+    add_mpi(make_step_parser(subparsers, Command.CROSS_CORRELATE, ["raw_data", "ccf", "xml"]))
     add_mpi(make_step_parser(subparsers, Command.STACK, ["raw_data", "stack", "ccf"]))
     add_mpi(make_step_parser(subparsers, Command.ALL, ["raw_data", "ccf", "stack", "xml"]))
 

--- a/src/noisepy/seis/scheduler.py
+++ b/src/noisepy/seis/scheduler.py
@@ -81,7 +81,7 @@ class MPIScheduler(Scheduler):
     def get_indices(self, items: list) -> List[int]:
         rank = self.comm.Get_rank()
         size = self.comm.Get_size()
-        
+
         rng = range(rank, len(items), size)
         indices = list(rng)
         logger.debug(f"RANK {rank}, INDICES: {indices}")

--- a/src/noisepy/seis/scheduler.py
+++ b/src/noisepy/seis/scheduler.py
@@ -81,7 +81,7 @@ class MPIScheduler(Scheduler):
     def get_indices(self, items: list) -> List[int]:
         rank = self.comm.Get_rank()
         size = self.comm.Get_size()
-        rank = self.comm.Get_rank()
+        
         rng = range(rank, len(items), size)
         indices = list(rng)
         logger.debug(f"RANK {rank}, INDICES: {indices}")

--- a/src/noisepy/seis/scheduler.py
+++ b/src/noisepy/seis/scheduler.py
@@ -1,0 +1,91 @@
+import logging
+from abc import ABC, abstractmethod
+from typing import Callable, List
+
+logger = logging.getLogger(__name__)
+
+
+class Scheduler(ABC):
+    """A minimal abstraction to select work to do in a process"""
+
+    @abstractmethod
+    def initialize(self, initializer: Callable[[], List], shared_vars: int) -> List:
+        """
+        Initialize the scheduler
+        Args:
+            initializer: Function to call to initialize shared state variables
+            shared_vars: Number of variables that the initializer will return
+        Returns:
+            List of variables return by the initializer
+        """
+        pass
+
+    @abstractmethod
+    def get_indices(items: list) -> list[int]:
+        """Get the indices of the items this process should work on"""
+        pass
+
+    @abstractmethod
+    def synchronize(self):
+        """Synchronizes all processes at the point this method is called"""
+        pass
+
+
+class SingleNodeScheduler(Scheduler):
+    """A basic Scheduler implementation for a single process"""
+
+    def initialize(self, initializer: Callable[[], List], shared_vars: int) -> List:
+        return initializer()
+
+    def get_indices(self, items: list) -> list[int]:
+        indices = list(range(len(items)))
+        logger.debug(f"RANK -, INDICES: {indices}")
+        return indices
+
+    def synchronize(self):
+        pass
+
+
+class MPIScheduler(Scheduler):
+    """A Scheduler implementation that uses MPI to distribute the work across a set of processes"""
+
+    def __init__(self, root: int = 0) -> None:
+        from mpi4py import MPI
+
+        super().__init__()
+        self.comm = MPI.COMM_WORLD
+        self.root = root
+
+    def initialize(self, initializer: Callable[[], List], shared_vars: int) -> List:
+        rank = self.comm.Get_rank()
+        if rank == self.root:
+            variables = initializer()
+            if len(variables) != shared_vars:
+                raise ValueError(
+                    f"The shared_vars argument ({shared_vars}) must match the number of values returned "
+                    f"by the initializer ({len(variables)})"
+                )
+            for v in variables:
+                # send shared variables
+                self.comm.bcast(v, root=self.root)
+            logger.debug(f"RANK {rank}, variables = {variables}")
+            return variables
+        else:
+            vars = []
+            for i in range(shared_vars):
+                # receive shared variables
+                vars.append(self.comm.bcast(None, root=self.root))
+            logger.debug(f"RANK {rank}, vars = {vars}")
+            return vars
+
+    def get_indices(self, items: list) -> list[int]:
+        rank = self.comm.Get_rank()
+        size = self.comm.Get_size()
+        rank = self.comm.Get_rank()
+        rng = range(rank, len(items), size)
+        indices = list(rng)
+        logger.debug(f"RANK {rank}, INDICES: {indices}")
+        return indices
+
+    def synchronize(self):
+        self.comm.barrier()

--- a/src/noisepy/seis/scheduler.py
+++ b/src/noisepy/seis/scheduler.py
@@ -78,7 +78,7 @@ class MPIScheduler(Scheduler):
             logger.debug(f"RANK {rank}, vars = {vars}")
             return vars
 
-    def get_indices(self, items: list) -> list[int]:
+    def get_indices(self, items: list) -> List[int]:
         rank = self.comm.Get_rank()
         size = self.comm.Get_size()
         rank = self.comm.Get_rank()

--- a/src/noisepy/seis/scheduler.py
+++ b/src/noisepy/seis/scheduler.py
@@ -21,7 +21,7 @@ class Scheduler(ABC):
         pass
 
     @abstractmethod
-    def get_indices(items: list) -> list[int]:
+    def get_indices(items: list) -> List[int]:
         """Get the indices of the items this process should work on"""
         pass
 
@@ -37,7 +37,7 @@ class SingleNodeScheduler(Scheduler):
     def initialize(self, initializer: Callable[[], List], shared_vars: int) -> List:
         return initializer()
 
-    def get_indices(self, items: list) -> list[int]:
+    def get_indices(self, items: list) -> List[int]:
         indices = list(range(len(items)))
         logger.debug(f"RANK -, INDICES: {indices}")
         return indices

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -6,7 +6,9 @@ noisepy download --start_date 2019-02-01T00:00:00 --end_date 2019-02-01T01:00:00
 # rm -rf $RUNNER_TEMP/CCF
 noisepy cross_correlate --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --freq_norm rma --log ${LOG_LEVEL}
 # rm -rf $RUNNER_TEMP/STACK
-noisepy stack --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method all --log ${LOG_LEVEL}
+mpiexec -n 3 noisepy stack --mpi --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method all --log ${LOG_LEVEL}
+rm -rf $RUNNER_TEMP/STACK
+noisepy stack --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method all --log ${LOG_LEVEL} 2>&1 > log.txt
 rm -rf $RUNNER_TEMP
 noisepy all --start_date 2019-02-01T00:00:00 --end_date 2019-02-01T01:00:00 --stations ARV,BAK --inc_hours 1 --raw_data_path $RUNNER_TEMP/RAW_DATA \
        --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method all --freq_norm rma --log ${LOG_LEVEL}

--- a/tutorials/cli/README.md
+++ b/tutorials/cli/README.md
@@ -31,7 +31,11 @@ This step will perform the cross correlation. For each time chunk, it will read 
 ```sh
 noisepy cross_correlate --raw_data_path ./tmpdata/RAW_DATA --ccf_path ./tmpdata/CCF
 ```
+Optionally, this step can be run via MPI (e.g. with 2 processes). See [Installation](../../README.md#installation):
 
+```sh
+mpiexec -n 2 noisepy cross_correlate --mpi --raw_data_path ./tmpdata/RAW_DATA --ccf_path ./tmpdata/CCF
+```
 NOTE: We didn't pass a `--config` argument explicitly because `noisepy` will always look for one in the input data directory for the given step, `./tmpdata/RAW_DATA` in this case.
 
 Once again, verify the data for this step:

--- a/tutorials/cli/README.md
+++ b/tutorials/cli/README.md
@@ -46,7 +46,12 @@ This combines the time-chunked ASDF files to stack over each time chunk and at e
 ```sh
 noisepy stack --ccf_path ./tmpdata/CCF --stack_path ./tmpdata/STACK
 ```
+Optionally, this step can be run via MPI (e.g. with 3 processes). See [Installation](../../README.md#installation):
+```sh
+mpiexec -n 3 noisepy stack --mpi --ccf_path ./tmpdata/CCF --stack_path ./tmpdata/STACK
+```
+
 
 ```sh
-ls -R tmpdata/STAC
+ls -R tmpdata/STACK
 ```


### PR DESCRIPTION
Having MPI as a core dependency presented several difficulties. It requires an MPI implementation, which is often platform dependent and takes longer to install. Installing MPI was one of the difficulties people faced on the last workshop. Furthermore, it's typically not required in cloud or single machine deployments.

This PR makes it an optional dependency by:
- Adding a `Scheduler`  abstraction to factor out the MPI/non-MPI details from the main computation
- Making mpi an optional dependency (ie `[mpi]`)
- Adding support for the CLI through a `--mpi` argument
- Updating the CI testing to not require MPI for the bulk of the tests (faster) but adding a specific MPI test