### PR TITLE
ZarrCCStore implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "pydantic>=1.10.0",
     "PyYAML>=6.0",
     "pydantic-yaml>=0.11",
+     "zarr>=2.14.2",
 ]
 
 

--- a/src/noisepy/seis/S2_stacking.py
+++ b/src/noisepy/seis/S2_stacking.py
@@ -71,7 +71,7 @@ def stack(
     #######################################
     def initializer():
         timespans = cc_store.get_timespans()
-        pairs_all = list(set(pair for ts in timespans for pair in cc_store.get_station_pairs(ts)))
+        pairs_all = cc_store.get_station_pairs()
         logger.info(f"Station pairs: {pairs_all}")
 
         if len(timespans) == 0 or len(pairs_all) == 0:

--- a/src/noisepy/seis/asdfstore.py
+++ b/src/noisepy/seis/asdfstore.py
@@ -159,12 +159,12 @@ class ASDFCCStore(CrossCorrelationDataStore):
 
     def get_station_pairs(self) -> List[Tuple[Station, Station]]:
         timespans = self.get_timespans()
-        pairs_all = []
+        pairs_all = set()
         for timespan in timespans:
             with self.datasets[timespan] as ccf_ds:
                 data = ccf_ds.auxiliary_data.list()
-                pairs_all.extend(parse_station_pair(p) for p in data if p != PROGRESS_DATATYPE)
-        return list(set(pairs_all))
+                pairs_all.update(parse_station_pair(p) for p in data if p != PROGRESS_DATATYPE)
+        return list(pairs_all)
 
     def get_channeltype_pairs(
         self, timespan: DateTimeRange, src_sta: Station, rec_sta: Station

--- a/src/noisepy/seis/zarrstore.py
+++ b/src/noisepy/seis/zarrstore.py
@@ -1,0 +1,109 @@
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+import zarr
+from datetimerange import DateTimeRange
+
+from noisepy.seis.constants import DONE_PATH
+
+from .datatypes import Channel, ChannelType, Station
+from .stores import (
+    CrossCorrelationDataStore,
+    parse_station_pair,
+    parse_timespan,
+    timespan_str,
+)
+
+
+class ZarrCCStore(CrossCorrelationDataStore):
+    """
+    TODO:
+    docs
+    make chunking an argument
+    update tutorials to use Zarr?
+    update CLI to use Zarr?
+    /                           (root)
+        station_pair            (group)
+            timestamp           (group)
+                channel_pair    (array)
+        'done'                  (array)
+    """
+
+    def __init__(self, root_dir: str, mode: str = "w") -> None:
+        super().__init__()
+        self.chunks = (1000, 1000)
+        self.root = zarr.open(root_dir, mode=mode)
+
+    def contains(self, timespan: DateTimeRange, src_chan: Channel, rec_chan: Channel) -> bool:
+        path = self._get_path(timespan, src_chan, rec_chan)
+        return path in self.root
+
+    def append(
+        self,
+        timespan: DateTimeRange,
+        src_chan: Channel,
+        rec_chan: Channel,
+        cc_params: Dict[str, Any],
+        data: np.ndarray,
+    ):
+        path = self._get_path(timespan, src_chan, rec_chan)
+        array = self.root.require_dataset(
+            path,
+            shape=data.shape,
+            chunks=self.chunks,
+            dtype=data.dtype,
+        )
+        array[:] = data
+        for k, v in cc_params.items():
+            array.attrs[k] = v
+
+    def is_done(self, timespan: DateTimeRange):
+        if DONE_PATH not in self.root.array_keys():
+            return False
+        done_array = self.root[DONE_PATH]
+        return timespan_str(timespan) in done_array.attrs.keys()
+
+    def mark_done(self, timespan: DateTimeRange):
+        done_array = self.root.require_dataset(DONE_PATH, shape=(1, 1))
+        done_array.attrs[timespan_str(timespan)] = True
+
+    def get_timespans(self) -> List[DateTimeRange]:
+        pairs = [k for k in self.root.group_keys() if k != DONE_PATH]
+        timespans = []
+        for p in pairs:
+            timespans.extend(k for k in self.root[p].group_keys())
+        return list(parse_timespan(t) for t in sorted(set(timespans)))
+
+    def get_station_pairs(self) -> List[Tuple[Station, Station]]:
+        pairs = [parse_station_pair(k) for k in self.root.group_keys() if k != DONE_PATH]
+        return pairs
+
+    def get_channeltype_pairs(
+        self, timespan: DateTimeRange, src_sta: Station, rec_sta: Station
+    ) -> List[Tuple[ChannelType, ChannelType]]:
+        path = self._get_station_path(timespan, src_sta, rec_sta)
+        if path not in self.root:
+            return []
+        ch_pairs = self.root[path].array_keys()
+        return [tuple(map(ChannelType, ch.split("_"))) for ch in ch_pairs]
+
+    def read(
+        self, timespan: DateTimeRange, src_sta: Station, rec_sta: Station, src_ch: ChannelType, rec_ch: ChannelType
+    ) -> Tuple[Dict, np.ndarray]:
+        path = self._get_path(timespan, Channel(src_ch, src_sta), Channel(rec_ch, rec_sta))
+        if path not in self.root:
+            return ({}, np.empty)
+        array = self.root[path]
+        data = array[:]
+        params = {k: array.attrs[k] for k in array.attrs.keys()}
+        return (params, data)
+
+    def _get_station_path(self, timespan: DateTimeRange, src_sta: Station, rec_sta: Station) -> str:
+        stations = self._get_station_pair(src_sta, rec_sta)
+        times = timespan_str(timespan)
+        return f"{stations}/{times}"
+
+    def _get_path(self, timespan: DateTimeRange, src_chan: Channel, rec_chan: Channel) -> str:
+        channels = self._get_channel_pair(src_chan.type, rec_chan.type)
+        station_path = self._get_station_path(timespan, src_chan.station, rec_chan.station)
+        return f"{station_path}/{channels}"

--- a/tests/test_asdfstore.py
+++ b/tests/test_asdfstore.py
@@ -1,12 +1,9 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from pathlib import Path
 
-import numpy as np
 import pytest
-from datetimerange import DateTimeRange
 
 from noisepy.seis.asdfstore import ASDFCCStore, ASDFRawDataStore
-from noisepy.seis.datatypes import Channel, ChannelType, Station
 
 
 @pytest.fixture
@@ -45,48 +42,3 @@ def test_get_data(store: ASDFRawDataStore):
     assert chdata.data.size == 72001
     assert chdata.sampling_rate == 20.0
     assert chdata.start_timestamp == ts.start_datetime.timestamp()
-
-
-def test_ccstore(ccstore: ASDFCCStore):
-    def make_1dts(dt: datetime):
-        dt = dt.replace(tzinfo=timezone.utc, microsecond=0)
-        return DateTimeRange(dt, dt + timedelta(days=1))
-
-    data = np.zeros(0)
-    ts1 = make_1dts(datetime.now())
-    ts2 = make_1dts(ts1.end_datetime)
-    src = Channel(ChannelType("foo"), Station("nw", "sta1"))
-    rec = Channel(ChannelType("bar"), Station("nw", "sta2"))
-
-    # assert empty state
-    assert not ccstore.is_done(ts1)
-    assert not ccstore.is_done(ts2)
-    assert not ccstore.contains(ts1, src, rec)
-    assert not ccstore.contains(ts2, src, rec)
-
-    # add CC (src->rec) for ts1
-    ccstore.append(ts1, src, rec, {}, data)
-    # assert ts1 is there, but not ts2
-    assert ccstore.contains(ts1, src, rec)
-    assert not ccstore.contains(ts2, src, rec)
-    # also rec->src should not be there for ts1
-    assert not ccstore.contains(ts1, rec, src)
-    assert not ccstore.is_done(ts1)
-    # now mark ts1 done and assert it
-    ccstore.mark_done(ts1)
-    assert ccstore.is_done(ts1)
-    assert not ccstore.is_done(ts2)
-
-    # now add CC for ts2
-    ccstore.append(ts2, src, rec, {}, data)
-    assert ccstore.contains(ts2, src, rec)
-    assert not ccstore.is_done(ts2)
-    ccstore.mark_done(ts2)
-    assert ccstore.is_done(ts2)
-
-    timespans = ccstore.get_timespans()
-    assert timespans == [ts1, ts2]
-    sta_pairs = ccstore.get_station_pairs(ts1)
-    assert sta_pairs == [(src.station, rec.station)]
-    cha_pairs = ccstore.get_channeltype_pairs(ts1, sta_pairs[0][0], sta_pairs[0][1])
-    assert cha_pairs == [(src.type, rec.type)]

--- a/tests/test_ccstores.py
+++ b/tests/test_ccstores.py
@@ -1,0 +1,74 @@
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+import pytest
+from datetimerange import DateTimeRange
+
+from noisepy.seis.asdfstore import ASDFCCStore
+from noisepy.seis.datatypes import Channel, ChannelType, Station
+from noisepy.seis.stores import CrossCorrelationDataStore
+from noisepy.seis.zarrstore import ZarrCCStore
+
+
+@pytest.fixture
+def asdfstore(tmp_path: Path) -> ASDFCCStore:
+    return ASDFCCStore(str(tmp_path))
+
+
+@pytest.fixture
+def zarrstore(tmp_path: Path) -> ZarrCCStore:
+    return ZarrCCStore(str(tmp_path))
+
+
+def _ccstore_test_helper(ccstore: CrossCorrelationDataStore):
+    def make_1dts(dt: datetime):
+        dt = dt.replace(tzinfo=timezone.utc, microsecond=0)
+        return DateTimeRange(dt, dt + timedelta(days=1))
+
+    data = np.zeros((10, 10))
+    ts1 = make_1dts(datetime.now())
+    ts2 = make_1dts(ts1.end_datetime)
+    src = Channel(ChannelType("foo"), Station("nw", "sta1"))
+    rec = Channel(ChannelType("bar"), Station("nw", "sta2"))
+
+    # assert empty state
+    assert not ccstore.is_done(ts1)
+    assert not ccstore.is_done(ts2)
+    assert not ccstore.contains(ts1, src, rec)
+    assert not ccstore.contains(ts2, src, rec)
+
+    # add CC (src->rec) for ts1
+    ccstore.append(ts1, src, rec, {}, data)
+    # assert ts1 is there, but not ts2
+    assert ccstore.contains(ts1, src, rec)
+    assert not ccstore.contains(ts2, src, rec)
+    # also rec->src should not be there for ts1
+    assert not ccstore.contains(ts1, rec, src)
+    assert not ccstore.is_done(ts1)
+    # now mark ts1 done and assert it
+    ccstore.mark_done(ts1)
+    assert ccstore.is_done(ts1)
+    assert not ccstore.is_done(ts2)
+
+    # now add CC for ts2
+    ccstore.append(ts2, src, rec, {}, data)
+    assert ccstore.contains(ts2, src, rec)
+    assert not ccstore.is_done(ts2)
+    ccstore.mark_done(ts2)
+    assert ccstore.is_done(ts2)
+
+    timespans = ccstore.get_timespans()
+    assert timespans == [ts1, ts2]
+    sta_pairs = ccstore.get_station_pairs()
+    assert sta_pairs == [(src.station, rec.station)]
+    cha_pairs = ccstore.get_channeltype_pairs(ts1, sta_pairs[0][0], sta_pairs[0][1])
+    assert cha_pairs == [(src.type, rec.type)]
+
+
+def test_asdfccstore(asdfstore: ASDFCCStore):
+    _ccstore_test_helper(asdfstore)
+
+
+def test_zarrccstore(zarrstore: ZarrCCStore):
+    _ccstore_test_helper(zarrstore)


### PR DESCRIPTION
Implementation of a CrossCorrelationStore using Zarr 

Changes:
- Update CrossCorrelationStore interface to be more general
- Move various helper functions from `asdfstore.py` to `stores.py` to use across the two types of store
- Implement ZarrCCStore
- Refactor unit tests to share the testing code between the two stores

TODO:
- Update `plotting_module` to use a CrossCorrelationStore instead of direct `.h5` file access so that CCs stored in Zarr can be plotted
- Update tutorials to use Zarr?
- Update CLI to support Zarr and add this to the test matrix