### PR TITLE
Add support for multiple network names and channel type

### DIFF
--- a/src/noisepy/seis/plotting_modules.py
+++ b/src/noisepy/seis/plotting_modules.py
@@ -173,7 +173,7 @@ def plot_substack_cc(sfile, freqmin, freqmax, disp_lag=None, savefig=True, sdir=
         ttr = spair.split("_")
         net1, sta1 = ttr[0].split(".")
         net2, sta2 = ttr[1].split(".")
-        for ipath in ds.auxiliary_data[spair].list():
+        for ipath in path_lists:
             chan1, chan2 = ipath.split("_")
             try:
                 dist = ds.auxiliary_data[spair][ipath].parameters["dist"]

--- a/src/noisepy/seis/plotting_modules.py
+++ b/src/noisepy/seis/plotting_modules.py
@@ -173,7 +173,7 @@ def plot_substack_cc(sfile, freqmin, freqmax, disp_lag=None, savefig=True, sdir=
         ttr = spair.split("_")
         net1, sta1 = ttr[0].split(".")
         net2, sta2 = ttr[1].split(".")
-        for ipath in path_lists:
+        for ipath in ds.auxiliary_data[spair].list():
             chan1, chan2 = ipath.split("_")
             try:
                 dist = ds.auxiliary_data[spair][ipath].parameters["dist"]

--- a/src/noisepy/seis/pnwstore.py
+++ b/src/noisepy/seis/pnwstore.py
@@ -17,19 +17,6 @@ from .utils import fs_join, get_filesystem
 logger = logging.getLogger(__name__)
 
 
-def channel_filter(stations: List[str], ch_prefixes: str) -> Callable[[Channel], bool]:
-    """
-    Helper function for creating a channel filter to be used in the constructor of the store.
-    This filter uses a list of allowed station name along with a channel filter prefix.
-    """
-    sta_set = set(stations)
-
-    def filter(ch: Channel) -> bool:
-        return ch.station.name in sta_set and ch.type.name.lower().startswith(tuple(ch_prefix.lower().split(",")))
-
-    return filter
-
-
 class PNWDataStore(RawDataStore):
     """
     A data store implementation to read from a SQLite DB of metadata and a directory of data files

--- a/src/noisepy/seis/pnwstore.py
+++ b/src/noisepy/seis/pnwstore.py
@@ -17,6 +17,19 @@ from .utils import fs_join, get_filesystem
 logger = logging.getLogger(__name__)
 
 
+def channel_filter(stations: List[str], ch_prefix: str) -> Callable[[Channel], bool]:
+    """
+    Helper function for creating a channel filter to be used in the constructor of the store.
+    This filter uses a list of allowed station name along with a channel filter prefix.
+    """
+    sta_set = set(stations)
+
+    def filter(ch: Channel) -> bool:
+        return ch.station.name in sta_set and ch.type.name.lower().startswith(tuple(ch_prefix.lower().split(",")))
+
+    return filter
+
+
 class PNWDataStore(RawDataStore):
     """
     A data store implementation to read from a SQLite DB of metadata and a directory of data files

--- a/src/noisepy/seis/pnwstore.py
+++ b/src/noisepy/seis/pnwstore.py
@@ -17,7 +17,7 @@ from .utils import fs_join, get_filesystem
 logger = logging.getLogger(__name__)
 
 
-def channel_filter(stations: List[str], ch_prefix: str) -> Callable[[Channel], bool]:
+def channel_filter(stations: List[str], ch_prefixes: str) -> Callable[[Channel], bool]:
     """
     Helper function for creating a channel filter to be used in the constructor of the store.
     This filter uses a list of allowed station name along with a channel filter prefix.

--- a/src/noisepy/seis/pnwstore.py
+++ b/src/noisepy/seis/pnwstore.py
@@ -123,7 +123,7 @@ class PNWDataStore(RawDataStore):
 
         # reconstruct the file name from the channel parameters
         chan_str = f"{chan.station.name}.{chan.station.network}.{timespan.start_datetime.strftime('%Y.%j')}"
-        filename = fs_join(self.paths[timespan.start_datetime], f"{chan_str}")
+        filename = fs_join(self.paths[timespan.start_datetime].replace("__", chan.station.network), f"{chan_str}")
         if not self.fs.exists(filename):
             logger.warning(f"Could not find file {filename}")
             return ChannelData.empty()

--- a/src/noisepy/seis/scedc_s3store.py
+++ b/src/noisepy/seis/scedc_s3store.py
@@ -16,7 +16,7 @@ from .utils import fs_join, get_filesystem
 logger = logging.getLogger(__name__)
 
 
-def channel_filter(stations: List[str], ch_prefix: str) -> Callable[[Channel], bool]:
+def channel_filter(stations: List[str], ch_prefixes: str) -> Callable[[Channel], bool]:
     """
     Helper function for creating a channel filter to be used in the constructor of the store.
     This filter uses a list of allowed station name along with a channel filter prefix.
@@ -24,7 +24,7 @@ def channel_filter(stations: List[str], ch_prefix: str) -> Callable[[Channel], b
     sta_set = set(stations)
 
     def filter(ch: Channel) -> bool:
-        return ch.station.name in sta_set and ch.type.name.lower().startswith(ch_prefix.lower())
+        return ch.station.name in sta_set and ch.type.name.lower().startswith(tuple(ch_prefixes.lower().split(",")))
 
     return filter
 

--- a/tutorials/noisepy_pnwstore_tutorial.ipynb
+++ b/tutorials/noisepy_pnwstore_tutorial.ipynb
@@ -286,7 +286,7 @@
    },
    "outputs": [],
    "source": [
-    "file = os.path.join(cc_data_path, '2020_01_02_00_00_00T2020_01_03_00_00_00.h5')\n",
+    "file = os.path.join(cc_data_path, '2020_01_03_00_00_00T2020_01_04_00_00_00.h5')\n",
     "plotting_modules.plot_substack_cc(file,0.1,1,None,False)"
    ]
   },
@@ -367,9 +367,9 @@
   },
   "gpuClass": "standard",
   "kernelspec": {
-   "display_name": "noisepy",
+   "display_name": ".env",
    "language": "python",
-   "name": "noisepy"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/noisepy_pnwstore_tutorial.ipynb
+++ b/tutorials/noisepy_pnwstore_tutorial.ipynb
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "id": "vceZgD83PnNc"
    },
@@ -75,8 +75,7 @@
    "source": [
     "from noisepy.seis import cross_correlate, stack, plotting_modules       # noisepy core functions\n",
     "from noisepy.seis.asdfstore import ASDFCCStore, ASDFStackStore                          # Object to store ASDF data within noisepy\n",
-    "from noisepy.seis.scedc_s3store import channel_filter # Object to query SCEDC data from on S3\n",
-    "from noisepy.seis.pnwstore import PNWDataStore\n",
+    "from noisepy.seis.pnwstore import PNWDataStore, channel_filter\n",
     "from noisepy.seis.datatypes import ConfigParameters, Channel, ChannelData, ChannelType, Station    # Main configuration object\n",
     "from noisepy.seis.channelcatalog import XMLStationChannelCatalog        # Required stationXML handling object\n",
     "import os\n",
@@ -95,13 +94,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2020-01-02T00:00:00 - 2020-01-04T00:00:00\n"
+     ]
+    }
+   ],
    "source": [
     "STATION_XML = \"/1-fnp/pnwstore1/p-wd11/PNWStationXML/\"            # storage of stationXML\n",
     "DATA = \"/1-fnp/pnwstore1/p-wd00/PNW2020/UW/\"\n",
-    "DB_PATH=\"/1-fnp/pnwstore1/p-wd00/PNW2020/timeseries.sqlite\"\n",
+    "DB_PATH=\"/data/wsd01/PNWstore_sqlite/2020.sqlite\"\n",
     "# timeframe for analysis\n",
     "start = datetime(2020, 1, 2)\n",
     "end = datetime(2020, 1, 4)\n",
@@ -140,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "id": "dIjBD7riIfdJ"
    },
@@ -161,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "id": "ByEiHRjmIAPB"
    },
@@ -210,9 +217,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# For this tutorial make sure the previous run is empty\n",
     "os.system(f\"rm -rf {cc_data_path}\")"
@@ -230,13 +248,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
-    "stations = \"BBO,BABR\".split(\",\") # filter to these stations\n",
+    "stations = \"BBO,BABR,SHUK\".split(\",\") # filter to these stations\n",
     "catalog = XMLStationChannelCatalog(STATION_XML, path_format=\"{network}\" + os.path.sep + \"{network}.{name}.xml\")\n",
-    "raw_store = PNWDataStore(DATA, catalog, DB_PATH, channel_filter(stations, \"HH\"), date_range=range) # Store for reading raw data from S3 bucket\n",
+    "raw_store = PNWDataStore(DATA, catalog, DB_PATH, channel_filter(stations, \"HH,BH\"), date_range=range) # Store for reading raw data from S3 bucket\n",
     "cc_store = ASDFCCStore(cc_data_path) # Store for writing CC data\n",
     "# print the configuration parameters. Some are chosen by default but we can modify them\n",
     "# print(config)"
@@ -355,9 +373,9 @@
   },
   "gpuClass": "standard",
   "kernelspec": {
-   "display_name": ".env",
+   "display_name": "noisepy",
    "language": "python",
-   "name": "python3"
+   "name": "noisepy"
   },
   "language_info": {
    "codemirror_mode": {
@@ -369,7 +387,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/tutorials/noisepy_pnwstore_tutorial.ipynb
+++ b/tutorials/noisepy_pnwstore_tutorial.ipynb
@@ -348,13 +348,6 @@
     "print(files)\n",
     "plotting_modules.plot_all_moveout(files, 'Allstack_linear', 0.1, 0.2, 'ZZ', 1)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/noisepy_pnwstore_tutorial.ipynb
+++ b/tutorials/noisepy_pnwstore_tutorial.ipynb
@@ -107,7 +107,7 @@
    ],
    "source": [
     "STATION_XML = \"/1-fnp/pnwstore1/p-wd11/PNWStationXML/\"            # storage of stationXML\n",
-    "DATA = \"/1-fnp/pnwstore1/p-wd00/PNW2020/UW/\"\n",
+    "DATA = \"/1-fnp/pnwstore1/p-wd00/PNW2020/__/\"\n",
     "DB_PATH=\"/data/wsd01/PNWstore_sqlite/2020.sqlite\"\n",
     "# timeframe for analysis\n",
     "start = datetime(2020, 1, 2)\n",

--- a/tutorials/noisepy_pnwstore_tutorial.ipynb
+++ b/tutorials/noisepy_pnwstore_tutorial.ipynb
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "metadata": {
     "id": "vceZgD83PnNc"
    },
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -107,8 +107,8 @@
    ],
    "source": [
     "STATION_XML = \"/1-fnp/pnwstore1/p-wd11/PNWStationXML/\"            # storage of stationXML\n",
-    "DATA = \"/1-fnp/pnwstore1/p-wd00/PNW2020/__/\"\n",
-    "DB_PATH=\"/data/wsd01/PNWstore_sqlite/2020.sqlite\"\n",
+    "DATA = \"/1-fnp/pnwstore1/p-wd00/PNW2020/__/\"                      # __ indicates any two chars (network code)\n",
+    "DB_PATH=\"/1-fnp/pnwstore1/p-wd00/PNW2020/timeseries.sqlite\"\n",
     "# timeframe for analysis\n",
     "start = datetime(2020, 1, 2)\n",
     "end = datetime(2020, 1, 4)\n",
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {
     "id": "dIjBD7riIfdJ"
    },
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {
     "id": "ByEiHRjmIAPB"
    },
@@ -217,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -226,7 +226,7 @@
        "0"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -248,13 +248,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "stations = \"BBO,BABR,SHUK\".split(\",\") # filter to these stations\n",
+    "# cross network, cross channel type\n",
+    "# UW.BBO..HH\n",
+    "# UW.BABR..HH\n",
+    "# UW.SHUK..BH\n",
+    "# CC.PANH..BH\n",
+    "stations = \"BBO,BABR,SHUK,PANH\".split(\",\") # filter to these stations\n",
     "catalog = XMLStationChannelCatalog(STATION_XML, path_format=\"{network}\" + os.path.sep + \"{network}.{name}.xml\")\n",
-    "raw_store = PNWDataStore(DATA, catalog, DB_PATH, channel_filter(stations, \"HH,BH\"), date_range=range) # Store for reading raw data from S3 bucket\n",
+    "raw_store = PNWDataStore(DATA, catalog, DB_PATH, channel_filter(stations, \"BH,HH\"), date_range=range) # Store for reading raw data from S3 bucket\n",
     "cc_store = ASDFCCStore(cc_data_path) # Store for writing CC data\n",
     "# print the configuration parameters. Some are chosen by default but we can modify them\n",
     "# print(config)"
@@ -299,7 +304,7 @@
    },
    "outputs": [],
    "source": [
-    "file = os.path.join(cc_data_path, '2020_01_03_00_00_00T2020_01_04_00_00_00.h5')\n",
+    "file = os.path.join(cc_data_path, '2020_01_02_00_00_00T2020_01_03_00_00_00.h5')\n",
     "plotting_modules.plot_substack_cc(file,0.1,1,None,False)"
    ]
   },

--- a/tutorials/noisepy_pnwstore_tutorial.ipynb
+++ b/tutorials/noisepy_pnwstore_tutorial.ipynb
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "id": "vceZgD83PnNc"
    },
@@ -75,7 +75,8 @@
    "source": [
     "from noisepy.seis import cross_correlate, stack, plotting_modules       # noisepy core functions\n",
     "from noisepy.seis.asdfstore import ASDFCCStore, ASDFStackStore                          # Object to store ASDF data within noisepy\n",
-    "from noisepy.seis.pnwstore import PNWDataStore, channel_filter\n",
+    "from noisepy.seis.scedc_s3store import channel_filter\n",
+    "from noisepy.seis.pnwstore import PNWDataStore\n",
     "from noisepy.seis.datatypes import ConfigParameters, Channel, ChannelData, ChannelType, Station    # Main configuration object\n",
     "from noisepy.seis.channelcatalog import XMLStationChannelCatalog        # Required stationXML handling object\n",
     "import os\n",
@@ -94,17 +95,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2020-01-02T00:00:00 - 2020-01-04T00:00:00\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "STATION_XML = \"/1-fnp/pnwstore1/p-wd11/PNWStationXML/\"            # storage of stationXML\n",
     "DATA = \"/1-fnp/pnwstore1/p-wd00/PNW2020/__/\"                      # __ indicates any two chars (network code)\n",
@@ -147,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "id": "dIjBD7riIfdJ"
    },
@@ -168,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "id": "ByEiHRjmIAPB"
    },
@@ -217,20 +210,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# For this tutorial make sure the previous run is empty\n",
     "os.system(f\"rm -rf {cc_data_path}\")"
@@ -248,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +282,7 @@
    "execution_count": null,
    "metadata": {
     "id": "pWcrfWO8W1tH",
-    "scrolled": false
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -366,6 +348,13 @@
     "print(files)\n",
     "plotting_modules.plot_all_moveout(files, 'Allstack_linear', 0.1, 0.2, 'ZZ', 1)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR contains some small modifications to the PNWDataStore object. After the modification, the PNWDataStore object now supports:
- channel filter for multiple channel types, e.g., loading HH,EH,BH at the same time
- reading data from multiple network name, e.g., UW, UO, CC, at the same time. The later one is achieved straightforward by modifying DATA path: we replace hardcoded network name to "__", which is the wildcard in the sqlite grammar indicating any two chars. 

See the updated tutorial (noisepy_pnwstore_tutorial.ipynb) for more information. We are doing more tests at this moment.