### PR TITLE
Add upper bounds to dependency versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,20 +33,20 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
 ]
 dependencies = [
-    "DateTimeRange==2.0.0",
-    "h5py>=3.8.0",
-    "numba>=0.57.0",
-    "numpy>=1.22.0",
-    "pandas>=1.5.3",
-    "pyasdf>=0.7.5",
-    "pycwt>=0.3.0a22",
-    "diskcache>=5.5",
-    "fsspec>=2023.4.0",
-    "s3fs>=2023.4.0",
-    "pydantic>=2.0.0",
-    "PyYAML>=6.0",
-    "pydantic-yaml>=1.0",
-     "zarr>=2.14.2",
+    "DateTimeRange==2.0.0,<3.0.0",
+    "h5py>=3.8.0,<4.0.0",
+    "numba>=0.57.0,<1.0.0",
+    "numpy>=1.22.0,<2.0.0",
+    "pandas>=1.5.3,<2.0.0",
+    "pyasdf>=0.7.5,<1.0.0",
+    "pycwt>=0.3.0a22,<1.0.0",
+    "diskcache>=5.5,<6.0",
+    "fsspec>=2023.4.0,<2024.0.0",
+    "s3fs>=2023.4.0,<2024.0.0",
+    "pydantic>=2.0.0,<3.0.0",
+    "PyYAML>=6.0,<7.0",
+    "pydantic-yaml>=1.0,<2.0",
+     "zarr>=2.14.2,<3.0.0",
 ]
 
 
@@ -72,15 +72,15 @@ packages = ["src/noisepy"]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.2.2",
-    "memory-profiler>=0.61",
-    "pre-commit>=3.2",
+    "pytest>=7.2.2,<8.0.0",
+    "memory-profiler>=0.61,<1.0.0",
+    "pre-commit>=3.2,<4.0.0",
 ]
 sql = [
     "SQLite3-0611",
 ]
 mpi = [
-    "mpi4py>=3.1.4",
+    "mpi4py>=3.1.4,<4.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Prevent inadvertently upgrading to a major version of a dependency