### PR TITLE
Support Zarr format from the CLI

### DIFF
--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -16,6 +16,6 @@ jobs:
       with:
         python-version: 3.8
     - name: Install pre-commit
-      run: pip install pre-commit==3.3
+      run: pip install pre-commit==3.3.3
     - name: Run pre-commit checks
       run: pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -16,6 +16,6 @@ jobs:
       with:
         python-version: 3.8
     - name: Install pre-commit
-      run: pip install pre-commit
+      run: pip install pre-commit==3.3
     - name: Run pre-commit checks
       run: pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,18 +42,18 @@ jobs:
       fail-fast: true
       matrix:
         python_version: ['3.8', '3.10']
-        method: [linear]
+        method: [linear,robust, nroot, selective, auto_covariance, pws]
         freq_norm: [rma]
         format: [asdf]
         include:
-        - method: [robust, nroot, selective, auto_covariance, pws]
-          python_version: ['3.8', '3.10']
-          freq_norm: [no]
-          format: [zarr]
-        - method: [robust]
-          python_version: ['3.8', '3.10']
-          freq_norm: [phase_only]
-          format: [zarr]
+        - method: linear
+          python_version: '3.10'
+          freq_norm: no
+          format: zarr
+        - method: robust
+          python_version: '3.8'
+          freq_norm: phase_only
+          format: zarr
     runs-on: ubuntu-22.04
     needs: s0_download
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,7 @@ jobs:
           freq_norm: no
           format: zarr
         - method: robust
-          python_version: '3.8'
+          python_version: '3.9'
           freq_norm: phase_only
           format: zarr
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,7 +75,7 @@ jobs:
     - name: Test Cross-Correlation (S1)
       working-directory: ./src
       run: |
-        noisepy cross_correlate --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --freq_norm ${{matrix.freq_norm}} --format ${{matrix.format}}}
+        noisepy cross_correlate --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --freq_norm ${{matrix.freq_norm}} --format ${{matrix.format}}
     - name: Test Stacking (S2)
       working-directory: ./src
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,8 +42,16 @@ jobs:
       fail-fast: true
       matrix:
         python_version: ['3.8', '3.10']
-        method: [linear, robust, nroot, selective, auto_covariance, pws]
-        freq_norm: [rma, no, phase_only]
+        method: [linear]
+        freq_norm: [rma]
+        format: [asdf]
+        include:
+        - method: [robust, nroot, selective, auto_covariance, pws]
+          freq_norm: [no]
+          format: [zarr]
+        - method: [robust]
+          freq_norm: [phase_only]
+          format: [zarr]
     runs-on: ubuntu-22.04
     needs: s0_download
     steps:
@@ -65,11 +73,11 @@ jobs:
     - name: Test Cross-Correlation (S1)
       working-directory: ./src
       run: |
-        noisepy cross_correlate --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --freq_norm ${{matrix.freq_norm}}
+        noisepy cross_correlate --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --freq_norm ${{matrix.freq_norm}} --format ${{matrix.format}}}
     - name: Test Stacking (S2)
       working-directory: ./src
       run: |
-        noisepy stack --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method ${{matrix.method}}
+        noisepy stack --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method ${{matrix.method}} --format ${{matrix.format}}
   s1_s2_mpi:
     strategy:
       fail-fast: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,9 +47,11 @@ jobs:
         format: [asdf]
         include:
         - method: [robust, nroot, selective, auto_covariance, pws]
+          python_version: ['3.8', '3.10']
           freq_norm: [no]
           format: [zarr]
         - method: [robust]
+          python_version: ['3.8', '3.10']
           freq_norm: [phase_only]
           format: [zarr]
     runs-on: ubuntu-22.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
       - id: check-json
       - id: check-yaml
       - id: pretty-format-json
+        files: \.(json|json5|js)$
         args: ["--autofix", "--indent=2", "--no-sort-keys"]
 
   - repo: https://github.com/PyCQA/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: check-json
       - id: check-yaml
       - id: pretty-format-json
-        files: \.(json|json5|js)$
+        exclude: \.ipy(n|nb)$
         args: ["--autofix", "--indent=2", "--no-sort-keys"]
 
   - repo: https://github.com/PyCQA/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.7.0
     hooks:
     - id: black
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ packages = ["src/noisepy"]
 dev = [
     "pytest>=7.2.2",
     "memory-profiler>=0.61",
-    "pre-commit>=3.2",
+    "pre-commit>=3.3,<4",
 ]
 sql = [
     "SQLite3-0611",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ packages = ["src/noisepy"]
 dev = [
     "pytest>=7.2.2",
     "memory-profiler>=0.61",
-    "pre-commit>=3.3,<4",
+    "pre-commit>=3.3.3,<4",
 ]
 sql = [
     "SQLite3-0611",

--- a/src/noisepy/seis/S2_stacking.py
+++ b/src/noisepy/seis/S2_stacking.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import time
 from typing import Any, Dict, List, Tuple
 
 import numpy as np
@@ -48,7 +49,7 @@ def stack(
     fft_params: ConfigParameters,
     scheduler: Scheduler = SingleNodeScheduler(),
 ):
-    tlog = TimeLogger(logger=logger)
+    tlog = TimeLogger(logger=logger, level=logging.INFO)
     t_tot = tlog.reset()
     if fft_params.rotation and fft_params.correction:
         if not fft_params.correction_csv:
@@ -87,6 +88,7 @@ def stack(
     # loop through each pair assigned to this process by the scheduler
     for ipair in scheduler.get_indices(pairs_all):
         tlog.reset()
+        t_append = 0.0
 
         logger.debug("%dth path for station-pair %s" % (ipair, pairs_all[ipair]))
         sta_pair = pairs_all[ipair]
@@ -161,8 +163,11 @@ def stack(
             bigstack2 = np.zeros(shape=(9, npts_segmt), dtype=np.float32)
 
         def write_stacks(comp: str, tparameters: Dict[str, Any], stacks: List[Tuple[StackMethod, np.ndarray]]):
+            nonlocal t_append
+            t_start = time.time()
             for method, data in stacks:
                 stack_store.append(src_sta, rec_sta, comp, f"Allstack_{method.value}", tparameters, data)
+            t_append += time.time() - t_start
 
         # loop through cross-component for stacking
         iflag = 1
@@ -216,8 +221,6 @@ def stack(
                     stack_name = "T" + str(int(stamps_final[ii]))
                     write_stacks(comp, tparameters, [(stack_name, cc_final[ii])])
 
-            tlog.log(f"stack one component with {fft_params.stack_method} stacking method")
-
         # do rotation if needed
         if fft_params.rotation and iflag:
             if np.all(bigstack == 0):
@@ -250,6 +253,7 @@ def stack(
                     ]
                     write_stacks(comp, tparameters, stacks)
         tlog.log(f"stack/rotate all station pairs {pairs_all[ipair]}", t_load)
+        tlog.log_raw("store.append", t_append)
 
         stack_store.mark_done(src_sta, rec_sta)
 

--- a/src/noisepy/seis/asdfstore.py
+++ b/src/noisepy/seis/asdfstore.py
@@ -229,7 +229,7 @@ class ASDFStackStore(StackStore):
 
 
 def _get_dataset(filename: str, mode: str) -> pyasdf.ASDFDataSet:
-    logger.debug(f"ASDFCCStore - Opening {filename}")
+    logger.debug(f"Opening {filename}")
     if os.path.exists(filename):
         return pyasdf.ASDFDataSet(filename, mode=mode, mpi=False, compression=None)
     elif mode == "r":

--- a/src/noisepy/seis/main.py
+++ b/src/noisepy/seis/main.py
@@ -39,8 +39,8 @@ class Command(Enum):
 
 
 class DataFormat(Enum):
-    ZARR = 1
-    ASDF = 2
+    ZARR = "zarr"
+    ASDF = "asdf"
 
 
 def valid_date(d: str) -> str:
@@ -161,14 +161,14 @@ def main(args: typing.Any):
     def get_cc_store(args, mode="a"):
         return (
             ZarrCCStore(args.ccf_path, mode=mode, chunks=(200, 8001))
-            if args.format == DataFormat.ZARR.name.lower()
+            if args.format == DataFormat.ZARR.value
             else ASDFCCStore(args.ccf_path, mode=mode)
         )
 
     def get_stack_store(args):
         return (
             ZarrStackStore(args.stack_path, mode="a", chunks=(8001,))
-            if args.format == DataFormat.ZARR.name.lower()
+            if args.format == DataFormat.ZARR.value
             else ASDFStackStore(args.stack_path, "w")
         )
 
@@ -236,8 +236,8 @@ def make_step_parser(subparsers: Any, cmd: Command, paths: List[str]) -> Any:
     if cmd != Command.DOWNLOAD:
         parser.add_argument(
             "--format",
-            default=DataFormat.ZARR.name.lower(),
-            choices=[f.name.lower() for f in DataFormat],
+            default=DataFormat.ZARR.value,
+            choices=[f.value for f in DataFormat],
             help="Format of the raw data files",
         )
     return parser

--- a/src/noisepy/seis/main.py
+++ b/src/noisepy/seis/main.py
@@ -160,14 +160,14 @@ def main(args: typing.Any):
 
     def get_cc_store(args, mode="a"):
         return (
-            ZarrCCStore(args.ccf_path, mode=mode, chunks=(200, 8001))
+            ZarrCCStore(args.ccf_path, mode=mode)
             if args.format == DataFormat.ZARR.value
             else ASDFCCStore(args.ccf_path, mode=mode)
         )
 
     def get_stack_store(args):
         return (
-            ZarrStackStore(args.stack_path, mode="a", chunks=(8001,))
+            ZarrStackStore(args.stack_path, mode="a")
             if args.format == DataFormat.ZARR.value
             else ASDFStackStore(args.stack_path, "w")
         )

--- a/src/noisepy/seis/utils.py
+++ b/src/noisepy/seis/utils.py
@@ -70,6 +70,10 @@ class TimeLogger:
         stop = time.time()
         dt = stop - self.time if start <= 0 else stop - start
         self.reset()
+        self.log_raw(message, dt)
+        return self.time
+
+    def log_raw(self, message: str, dt: float):
         if self.enabled:
             self.logger.log(self.level, f"TIMING: {dt:6.4f} for {message}")
         return self.time

--- a/src/noisepy/seis/zarrstore.py
+++ b/src/noisepy/seis/zarrstore.py
@@ -30,7 +30,7 @@ class ZarrStoreHelper:
 
     """
 
-    def __init__(self, root_dir: str, mode: str = "w", chunks: Tuple[int, int] = (4 * 1024, 4 * 1024)) -> None:
+    def __init__(self, root_dir: str, mode: str, chunks: Tuple[int, int]) -> None:
         super().__init__()
         self.chunks = chunks
         self.root = zarr.open(root_dir, mode=mode)
@@ -89,7 +89,7 @@ class ZarrCCStore(CrossCorrelationDataStore):
                 channel_pair    (array)
     """
 
-    def __init__(self, root_dir: str, mode: str = "w", chunks: Tuple[int, int] = (4 * 1024, 4 * 1024)) -> None:
+    def __init__(self, root_dir: str, mode: str = "a", chunks: Tuple[int, int] = (500, 500)) -> None:
         super().__init__()
         self.helper = ZarrStoreHelper(root_dir, mode, chunks)
 
@@ -159,7 +159,7 @@ class ZarrStackStore:
                 component       (array)
     """
 
-    def __init__(self, root_dir: str, mode: str = "w", chunks: Tuple[int] = (4 * 1024,)) -> None:
+    def __init__(self, root_dir: str, mode: str = "a", chunks: Tuple[int] = (500,)) -> None:
         super().__init__()
         self.helper = ZarrStoreHelper(root_dir, mode, chunks)
 

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -1,14 +1,42 @@
+#!/bin/zsh
+
 RUNNER_TEMP=~/test_temp
-LOG_LEVEL=debug
+LOG_LEVEL=info
+FORMAT=$1
+if [[ "$FORMAT" -ne "zarr" && "$FORMAT" -ne "asdf" ]]; then
+       echo "Missing FORMAT argument (zarr or asdf)"
+       exit 1
+fi
+echo "FORMAT is $FORMAT"
+LOGFILE="$HOME/logs/log_${FORMAT}_$(date -j +'%Y%m%d_%H%M%S').txt"
+STATIONS=ARV,BAK
+START=2019-02-01T00:00:00
+END=2019-02-01T01:00:00
+INC_HOURS=1
+
+# Uncomment for a bigger test
+# STATIONS=ADO,ALP,ARV,AVM,BAK,BAR,BBR,BBS,BC3,BCW
+# START=2019-02-01T00:00:00
+# END=2019-02-05T00:00:00
+# INC_HOURS=24
+
+function sum_logs {
+    SUM=$(cat $LOGFILE | grep "$1" |cut -d' ' -f 6,6 | paste -sd+ - | bc)
+    echo "SUM for $FORMAT/$1 is $SUM" | tee -a $LOGFILE
+}
 rm -rf $RUNNER_TEMP
 set -e
-noisepy download --start_date 2019-02-01T00:00:00 --end_date 2019-02-01T01:00:00 --stations ARV,BAK --inc_hours 1 --raw_data_path $RUNNER_TEMP/RAW_DATA --log ${LOG_LEVEL}
-# rm -rf $RUNNER_TEMP/CCF
-noisepy cross_correlate --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --freq_norm rma --log ${LOG_LEVEL}
-# rm -rf $RUNNER_TEMP/STACK
-mpiexec -n 3 noisepy stack --mpi --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method all --log ${LOG_LEVEL}
+noisepy download --start_date "${START}" --end_date "${END}" --stations "${STATIONS}" --inc_hours "${INC_HOURS}" --raw_data_path $RUNNER_TEMP/RAW_DATA --log ${LOG_LEVEL} 2>&1 | tee -a $LOGFILE
+rm -rf $RUNNER_TEMP/CCF
+noisepy cross_correlate --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --freq_norm rma --log ${LOG_LEVEL} --format ${FORMAT} 2>&1 | tee -a $LOGFILE
 rm -rf $RUNNER_TEMP/STACK
-noisepy stack --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method all --log ${LOG_LEVEL} 2>&1 > log.txt
+mpiexec -n 3 noisepy stack --mpi --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method all --log ${LOG_LEVEL} --format ${FORMAT} 2>&1 | tee -a $LOGFILE
+rm -rf $RUNNER_TEMP/STACK
+noisepy stack --raw_data_path $RUNNER_TEMP/RAW_DATA --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method all --log ${LOG_LEVEL} --format ${FORMAT} 2>&1 | tee -a $LOGFILE
 rm -rf $RUNNER_TEMP
 noisepy all --start_date 2019-02-01T00:00:00 --end_date 2019-02-01T01:00:00 --stations ARV,BAK --inc_hours 1 --raw_data_path $RUNNER_TEMP/RAW_DATA \
-       --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method all --freq_norm rma --log ${LOG_LEVEL}
+       --ccf_path $RUNNER_TEMP/CCF --stack_path $RUNNER_TEMP/STACK --stack_method all --freq_norm rma --log ${LOG_LEVEL} --format ${FORMAT} 2>&1 | tee -a $LOGFILE
+
+sum_logs "append"
+sum_logs "loading CCF"
+sum_logs "Append to store"


### PR DESCRIPTION
- Adds a `--format zarr|asdf` argument to the CLI
- Additional timing measurement and logging
- Update the test matrix to:
    - Include for format (zarr vs asdf)
    - Be more sparse. All types of normalization and stacking are tested, but not all combinations, which is overkill