### PR TITLE
Support for S3 and Zarr

### DIFF
--- a/src/noisepy/seis/datatypes.py
+++ b/src/noisepy/seis/datatypes.py
@@ -4,13 +4,16 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import Annotated, Any, DefaultDict, Dict, List, Optional
+from urllib.parse import urlparse
 
 import numpy as np
 import obspy
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.functional_validators import model_validator
 from pydantic_yaml import parse_yaml_raw_as, to_yaml_str
+
+from noisepy.seis.utils import get_filesystem
 
 INVALID_COORD = -sys.float_info.max
 
@@ -175,6 +178,16 @@ class ConfigParameters(BaseModel):
     correction_csv: Optional[str] = Field(default=None, description="Path to e.g. meso_angles.csv")
     # 'RESP', or 'polozeros' to remove response
 
+    storage_options: Annotated[
+        DefaultDict[str, Annotated[Dict[str, Any], Field(default_factory=dict)]],
+        Field(description="Storage options to pass to fsspec, keyed by protocol"),
+    ] = {}
+
+    def get_storage_options(self, path: str) -> Dict[str, Any]:
+        """The storage options for the given path"""
+        url = urlparse(path)
+        return self.storage_options.get(url.scheme, {})
+
     @property
     def dt(self) -> float:
         return 1.0 / self.samp_freq
@@ -194,11 +207,13 @@ class ConfigParameters(BaseModel):
 
     def save_yaml(self, filename: str):
         yaml_str = to_yaml_str(self)
-        with open(filename, "w") as f:
+        fs = get_filesystem(filename, storage_options=self.storage_options)
+        with fs.open(filename, "w") as f:
             f.write(yaml_str)
 
-    def load_yaml(filename: str) -> ConfigParameters:
-        with open(filename, "r") as f:
+    def load_yaml(filename: str, storage_options={}) -> ConfigParameters:
+        fs = get_filesystem(filename, storage_options=storage_options)
+        with fs.open(filename, "r") as f:
             yaml_str = f.read()
             config = parse_yaml_raw_as(ConfigParameters, yaml_str)
             return config

--- a/src/noisepy/seis/datatypes.py
+++ b/src/noisepy/seis/datatypes.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import sys
+import typing
+from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, Any, DefaultDict, Dict, List, Optional
+from typing import Any, DefaultDict, Dict, List, Optional
 from urllib.parse import urlparse
 
 import numpy as np
@@ -178,10 +180,10 @@ class ConfigParameters(BaseModel):
     correction_csv: Optional[str] = Field(default=None, description="Path to e.g. meso_angles.csv")
     # 'RESP', or 'polozeros' to remove response
 
-    storage_options: Annotated[
-        DefaultDict[str, Annotated[Dict[str, Any], Field(default_factory=dict)]],
-        Field(description="Storage options to pass to fsspec, keyed by protocol"),
-    ] = {}
+    storage_options: DefaultDict[str, typing.MutableMapping] = Field(
+        default=defaultdict(dict),
+        description="Storage options to pass to fsspec, keyed by protocol (local files are ''))",
+    )
 
     def get_storage_options(self, path: str) -> Dict[str, Any]:
         """The storage options for the given path"""

--- a/src/noisepy/seis/main.py
+++ b/src/noisepy/seis/main.py
@@ -158,33 +158,37 @@ def main(args: typing.Any):
         download(args.raw_data_path, params)
         params.save_yaml(fs_join(args.raw_data_path, CONFIG_FILE))
 
-    def get_cc_store(args, mode="a"):
+    def get_cc_store(args, params: ConfigParameters, mode="a"):
         return (
-            ZarrCCStore(args.ccf_path, mode=mode)
+            ZarrCCStore(
+                args.ccf_path,
+                mode=mode,
+                storage_options=params.get_storage_options(args.ccf_path),
+            )
             if args.format == DataFormat.ZARR.value
             else ASDFCCStore(args.ccf_path, mode=mode)
         )
 
-    def get_stack_store(args):
+    def get_stack_store(args, params: ConfigParameters):
         return (
-            ZarrStackStore(args.stack_path, mode="a")
+            ZarrStackStore(args.stack_path, mode="a", storage_options=params.get_storage_options(args.stack_path))
             if args.format == DataFormat.ZARR.value
             else ASDFStackStore(args.stack_path, "a")
         )
 
     def run_cross_correlation():
         ccf_dir = args.ccf_path
-        cc_store = get_cc_store(args)
         params = initialize_params(args, args.raw_data_path)
+        cc_store = get_cc_store(args, params)
         raw_store = create_raw_store(args, params)
         scheduler = MPIScheduler(0) if args.mpi else SingleNodeScheduler()
         cross_correlate(raw_store, params, cc_store, scheduler)
         params.save_yaml(fs_join(ccf_dir, CONFIG_FILE))
 
     def run_stack():
-        cc_store = get_cc_store(args, mode="r")
-        stack_store = get_stack_store(args)
         params = initialize_params(args, args.ccf_path)
+        cc_store = get_cc_store(args, params, mode="r")
+        stack_store = get_stack_store(args, params)
         scheduler = MPIScheduler(0) if args.mpi else SingleNodeScheduler()
         stack(cc_store, stack_store, params, scheduler)
         params.save_yaml(fs_join(args.stack_path, CONFIG_FILE))

--- a/src/noisepy/seis/utils.py
+++ b/src/noisepy/seis/utils.py
@@ -16,6 +16,8 @@ utils_logger = logging.getLogger(__name__)
 def get_filesystem(path: str, storage_options: dict = {}) -> fsspec.AbstractFileSystem:
     """Construct an fsspec filesystem for the given path"""
     url = urlparse(path)
+    # The storage_options coming from the ConfigParameters is keyed by protocol
+    storage_options = storage_options.get(url.scheme, storage_options)
     # default to anonymous access for S3 if the this is not already specified
     if url.scheme == S3_SCHEME and ANON_ARG not in storage_options:
         storage_options = {ANON_ARG: True}

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -48,5 +48,6 @@ def test_storage_options():
     c.storage_options["s3"] = {"profile": "my_profile"}
     assert c.get_storage_options("s3://my_bucket/my_file") == {"profile": "my_profile"}
 
-    c.storage_options["file"]["foo"] = "bar"
+    # scheme is '' for local files
+    c.storage_options[""]["foo"] = "bar"
     assert c.get_storage_options("/local/file") == {"foo": "bar"}

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -35,3 +35,18 @@ def test_station_valid():
     assert s.valid()
     s = Station("CI", "BAK", -110.0, 120.1, 15.0)
     assert s.valid()
+
+
+def test_storage_options():
+    c = ConfigParameters()
+    assert c.storage_options == {}
+    # make sure missing keys default to {}
+    assert c.storage_options["some_key"] == {}
+    c.storage_options["some_key"]["some_other_key"] = 6
+    assert c.storage_options["some_key"]["some_other_key"] == 6
+
+    c.storage_options["s3"] = {"profile": "my_profile"}
+    assert c.get_storage_options("s3://my_bucket/my_file") == {"profile": "my_profile"}
+
+    c.storage_options["file"]["foo"] = "bar"
+    assert c.get_storage_options("/local/file") == {"foo": "bar"}


### PR DESCRIPTION
Add `storage_options` to ConfigParameters to be able to specify authentication for S3 and other protocols. E.g.:
```
storage_options:
  s3:
    anon: false
    profile: "my_aws_test_profile"
```