### PR TITLE
Add single_freq parameter, bug fixes

### DIFF
--- a/src/noisepy/seis/datatypes.py
+++ b/src/noisepy/seis/datatypes.py
@@ -113,6 +113,12 @@ class ConfigParameters(BaseModel):
     start_date: datetime = Field(default=datetime(2019, 1, 1))
     end_date: datetime = Field(default=datetime(2019, 1, 2))
     samp_freq: float = Field(default=20.0)  # TODO: change this samp_freq for the obspy "sampling_rate"
+    single_freq: bool = Field(
+        default=True,
+        description="Filter to only data sampled at ONE frequency (the closest >= to samp_freq). "
+        "If False, it will use all data sample at >=samp_freq",
+    )
+
     cc_len: float = Field(default=1800.0, description="basic unit of data length for fft (sec)")
     # download params.
     # Targeted region/station information: only needed when down_list is False

--- a/src/noisepy/seis/plotting_modules.py
+++ b/src/noisepy/seis/plotting_modules.py
@@ -672,6 +672,7 @@ def plot_all_moveout(
     params, dtmp = store.read(sta_pairs[0][0], sta_pairs[0][1], ccomp, stack_name)
     if len(params) == 0 or dtmp.size == 0:
         logger.error(f"No data available for plotting {stack_name}/{ccomp}")
+        return
 
     dt, maxlag = (params[p] for p in ["dt", "maxlag"])
     stack_method = stack_name.split("0")[-1]
@@ -694,6 +695,9 @@ def plot_all_moveout(
     # load cc and parameter matrix
     for ii, (src, rec) in enumerate(sta_pairs):
         params, all_data = store.read(src, rec, ccomp, stack_name)
+        if len(params) == 0 or all_data.size == 0:
+            logger.warning(f"No data available for {src}_{rec}/{stack_name}/{ccomp}")
+            continue
         dist[ii] = params["dist"]
         ngood[ii] = params["ngood"]
 

--- a/tests/test_cross_correlation.py
+++ b/tests/test_cross_correlation.py
@@ -3,7 +3,6 @@ from noisepy.seis.S1_fft_cc_MPI import _filter_channel_data
 
 
 def test_read_channels():
-    # we should pick the closest frequency that is >= to the target freq, 60 in this case
     CLOSEST_FREQ = 60
     samp_freq = 40
     freqs = [10, 39, CLOSEST_FREQ, 100]
@@ -14,6 +13,13 @@ def test_read_channels():
         ch_data.append(cd)
     N = 5
     tuples = [(Channel("foo", Station("CI", "bar")), cd) for cd in ch_data] * N
-    filtered = _filter_channel_data(tuples, samp_freq)
+
+    # we should pick the closest frequency that is >= to the target freq, 60 in this case
+    filtered = _filter_channel_data(tuples, samp_freq, single_freq=True)
     assert N == len(filtered)
     assert [t[1].sampling_rate for t in filtered] == [CLOSEST_FREQ] * N
+
+    # we should get all data at >= 40 Hz (60 and 100)
+    filtered = _filter_channel_data(tuples, samp_freq, single_freq=False)
+    assert N * 2 == len(filtered)
+    assert all([t[1].sampling_rate >= samp_freq for t in filtered])


### PR DESCRIPTION
In some datasets (e.g. SCEDC S3 bucket) the data comes in multiple sampling rates and we need a way of selecting one. So the desired sampling rate is passed as a config parameter and we find the  sampling rate available in the data that is the closest (but equal or greater) than the config. Then we use only the data at that exact frequency.

However, in other scenarios we want to use all the data, as long as its above the desired sampling rate. This PR adds a configuration parameter to control this.

It also adds a couple of checks to avoid crashing when there's missing data.