### PR TITLE
Batch CC reads and writes for all channels

### DIFF
--- a/src/noisepy/seis/datatypes.py
+++ b/src/noisepy/seis/datatypes.py
@@ -276,3 +276,23 @@ class NoiseFFT:
     fft_time: np.ndarray
     window_count: int
     length: int
+
+
+class CrossCorrelation:
+    src: ChannelType
+    rec: ChannelType
+    parameters: Dict[str, Any]
+    data: np.ndarray
+
+    def __init__(self, src: ChannelType, rec: ChannelType, params: Dict[str, Any], data: np.ndarray):
+        self.src = src
+        self.rec = rec
+        self.data = data
+        self.parameters = {k: _to_json_type(v) for k, v in params.items()}
+
+
+def _to_json_type(value: Any) -> Any:
+    # special case since numpy arrays are not json serializable
+    if type(value) == np.ndarray:
+        return value.tolist()
+    return value

--- a/src/noisepy/seis/plotting_modules.py
+++ b/src/noisepy/seis/plotting_modules.py
@@ -155,13 +155,13 @@ def plot_substack_cc(
         logger.error("No data available for plotting")
         return
 
-    ch_pairs = cc_store.get_channeltype_pairs(ts, sta_pairs[0][0], sta_pairs[0][1])
-    if len(ch_pairs) == 0:
+    ccs = cc_store.read_correlations(ts, sta_pairs[0][0], sta_pairs[0][1])
+    if len(ccs) == 0:
         logger.error(f"No data available for plotting in {ts}/{sta_pairs[0]}")
         return
 
     # Read some common arguments from the first available data set:
-    params, _ = cc_store.read(ts, sta_pairs[0][0], sta_pairs[0][1], ch_pairs[0][0], ch_pairs[0][1])
+    params = ccs[0].parameters
     substack_flag, dt, maxlag = (params[p] for p in ["substack", "dt", "maxlag"])
 
     # only works for cross-correlation with substacks generated
@@ -182,10 +182,9 @@ def plot_substack_cc(
 
     # for spair in spairs:
     for src_sta, rec_sta in sta_pairs:
-        ch_pairs = cc_store.get_channeltype_pairs(ts, src_sta, rec_sta)
-        for src_cha, rec_cha in ch_pairs:
+        for cc in ccs:
+            src_cha, rec_cha, params, all_data = cc.src, cc.rec, cc.parameters, cc.data
             try:
-                params, all_data = cc_store.read(ts, src_sta, rec_sta, src_cha, rec_cha)
                 dist, ngood, ttime = (params[p] for p in ["dist", "ngood", "time"])
                 timestamp = np.empty(len(ttime), dtype="datetime64[s]")
             except Exception as e:

--- a/src/noisepy/seis/stores.py
+++ b/src/noisepy/seis/stores.py
@@ -9,7 +9,14 @@ from datetimerange import DateTimeRange
 
 from noisepy.seis.constants import DATE_FORMAT
 
-from .datatypes import Channel, ChannelData, ChannelType, ConfigParameters, Station
+from .datatypes import (
+    Channel,
+    ChannelData,
+    ChannelType,
+    ConfigParameters,
+    CrossCorrelation,
+    Station,
+)
 
 
 class DataStore(ABC):
@@ -52,10 +59,9 @@ class CrossCorrelationDataStore:
     def append(
         self,
         timespan: DateTimeRange,
-        src_chan: Channel,
-        rec_chan: Channel,
-        cc_params: Dict[str, Any],
-        data: np.ndarray,
+        src: Station,
+        rec: Station,
+        ccs: List[CrossCorrelation],
     ):
         pass
 
@@ -76,15 +82,7 @@ class CrossCorrelationDataStore:
         pass
 
     @abstractmethod
-    def get_channeltype_pairs(
-        self, timespan: DateTimeRange, src_sta: Station, rec_sta: Station
-    ) -> List[Tuple[ChannelType, ChannelType]]:
-        pass
-
-    @abstractmethod
-    def read(
-        self, timespan: DateTimeRange, src_sta: Station, rec_sta: Station, src_ch: ChannelType, rec_ch: ChannelType
-    ) -> Tuple[Dict, np.ndarray]:
+    def read_correlations(self, timespan: DateTimeRange, src_sta: Station, rec_sta: Station) -> List[CrossCorrelation]:
         pass
 
     # private helpers
@@ -92,7 +90,7 @@ class CrossCorrelationDataStore:
         return f"{src_sta}_{rec_sta}"
 
     def _get_channel_pair(self, src_chan: ChannelType, rec_chan: ChannelType) -> str:
-        return f"{src_chan.name}_{rec_chan.name}"
+        return f"{src_chan}_{rec_chan}"
 
 
 class StackStore:

--- a/src/noisepy/seis/utils.py
+++ b/src/noisepy/seis/utils.py
@@ -3,10 +3,11 @@ import os
 import posixpath
 import time
 from concurrent.futures import Future
-from typing import Iterable
+from typing import Iterable, List
 from urllib.parse import urlparse
 
 import fsspec
+import numpy as np
 
 S3_SCHEME = "s3"
 utils_logger = logging.getLogger(__name__)
@@ -94,3 +95,17 @@ def error_if(condition: bool, msg: str, error_type: type = RuntimeError):
 
 def _get_results(futures: Iterable[Future]) -> Iterable[Future]:
     return [f.result() for f in futures]
+
+
+def unstack(stack: np.ndarray, axis=0) -> List[np.ndarray]:
+    """
+    Split a stack along the given axis into a list of arrays
+    """
+    return [np.squeeze(a, axis=axis) for a in np.split(stack, stack.shape[axis], axis=axis)]
+
+
+def remove_nan_rows(a: np.ndarray) -> np.ndarray:
+    """
+    Remove rows from a 2D array that contain NaN values
+    """
+    return a[~np.isnan(a).any(axis=1)]

--- a/tests/test_ccstores.py
+++ b/tests/test_ccstores.py
@@ -65,15 +65,14 @@ def _ccstore_test_helper(ccstore: CrossCorrelationDataStore):
     assert timespans == [ts1, ts2]
     sta_pairs = ccstore.get_station_pairs()
     assert sta_pairs == [(src.station, rec.station)]
-    cha_pairs = ccstore.get_channeltype_pairs(ts1, sta_pairs[0][0], sta_pairs[0][1])
+    ccs = ccstore.read_correlations(ts1, sta_pairs[0][0], sta_pairs[0][1])
+    cha_pairs = [(c.src, c.rec) for c in ccs]
     assert cha_pairs == [(src.type, rec.type)]
-    read_params, read_data = ccstore.read(ts1, src.station, rec.station, src.type, rec.type)
-    assert params == read_params
-    assert np.all(data == read_data)
+    assert params == ccs[0].parameters
+    assert np.all(data == ccs[0].data)
 
-    read_params, read_data = ccstore.read(ts1, src.station, Station("nw", "wrong"), src.type, rec.type)
-    assert len(read_params) == 0
-    assert read_data.shape == (0, 0)
+    wrong_ccs = ccstore.read_correlations(ts1, src.station, Station("nw", "wrong"))
+    assert len(wrong_ccs) == 0
 
 
 def test_asdfccstore(asdfstore: ASDFCCStore):

--- a/tests/test_ccstores.py
+++ b/tests/test_ccstores.py
@@ -6,7 +6,7 @@ import pytest
 from datetimerange import DateTimeRange
 
 from noisepy.seis.asdfstore import ASDFCCStore
-from noisepy.seis.datatypes import Channel, ChannelType, Station
+from noisepy.seis.datatypes import Channel, ChannelType, CrossCorrelation, Station
 from noisepy.seis.stores import CrossCorrelationDataStore
 from noisepy.seis.zarrstore import ZarrCCStore
 
@@ -42,7 +42,7 @@ def _ccstore_test_helper(ccstore: CrossCorrelationDataStore):
     assert not ccstore.contains(ts2, src, rec)
 
     # add CC (src->rec) for ts1
-    ccstore.append(ts1, src, rec, params, data)
+    ccstore.append(ts1, src.station, rec.station, [CrossCorrelation(src.type, rec.type, params, data)])
     # assert ts1 is there, but not ts2
     assert ccstore.contains(ts1, src, rec)
     assert not ccstore.contains(ts2, src, rec)
@@ -55,7 +55,7 @@ def _ccstore_test_helper(ccstore: CrossCorrelationDataStore):
     assert not ccstore.is_done(ts2)
 
     # now add CC for ts2
-    ccstore.append(ts2, src, rec, {}, data)
+    ccstore.append(ts2, src.station, rec.station, [CrossCorrelation(src.type, rec.type, {}, data)])
     assert ccstore.contains(ts2, src, rec)
     assert not ccstore.is_done(ts2)
     ccstore.mark_done(ts2)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,9 @@
+import numpy as np
 import pytest
 from fsspec.implementations.local import LocalFileSystem
 from s3fs import S3FileSystem
 
-from noisepy.seis.utils import fs_join, get_filesystem
+from noisepy.seis.utils import fs_join, get_filesystem, remove_nan_rows, unstack
 
 paths = [
     ("/dir/", "file.csv", "/dir/file.csv"),
@@ -26,3 +27,18 @@ fs_types = [
 @pytest.mark.parametrize("path, fs_type", fs_types)
 def test_get_filesystem(path, fs_type):
     assert isinstance(get_filesystem(path), fs_type)
+
+
+def test_unstack():
+    array_list = [np.array([[1, 2, 3], [5, 6, 7]]), np.array([[7, 6, 5], [4, 3, 2]])]
+    stacked = np.stack(array_list, axis=0)
+    unstacked = unstack(stacked, axis=0)
+    assert len(unstacked) == len(array_list)
+    for i in range(len(array_list)):
+        assert np.all(unstacked[i] == array_list[i])
+
+
+def test_remove_nan_rows():
+    a = np.array([[1, 2, 3], [4, 5, 6], [np.nan, np.nan, np.nan]])
+    b = remove_nan_rows(a)
+    assert np.all(b == np.array([[1, 2, 3], [4, 5, 6]]))


### PR DESCRIPTION
This changes updates the CrossCorrelationStore interface to read and write all cross-correlations for a station pair at once (i.e. all channels). This allows for more efficient I/O and better parallelization when writing the data. 

Fixes https://github.com/mdenolle/NoisePy/issues/170