### PR TITLE
(fix) Fix parallelization of zarr writes

### DIFF
--- a/src/noisepy/seis/S1_fft_cc_MPI.py
+++ b/src/noisepy/seis/S1_fft_cc_MPI.py
@@ -213,6 +213,7 @@ def stations_cross_correlation(
     Nfft: int,
     cc_store: CrossCorrelationDataStore,
 ):
+    logger.info(f"Cross-correlating {len(channel_pairs)} pairs for {src} and {rec} for {ts}")
     datas = []
     # TODO: Are there any potential gains to parallelliing this? It could make a difference if
     # num station pairs < num cores since we are already parallelizing at the station pair level

--- a/src/noisepy/seis/__init__.py
+++ b/src/noisepy/seis/__init__.py
@@ -22,5 +22,7 @@ The main functions exported by the package are:
 - plotting_modules: Utility functions for plotting the data
 """
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(module)s.%(funcName)s(): %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(thread)d %(levelname)s %(module)s.%(funcName)s(): %(message)s"
+)
 logger = logging.getLogger(__name__)

--- a/src/noisepy/seis/datatypes.py
+++ b/src/noisepy/seis/datatypes.py
@@ -90,6 +90,9 @@ class Station:
     def __hash__(self) -> int:
         return str(self).__hash__()
 
+    def __eq__(self, __value: object) -> bool:
+        return str(self) == str(__value)
+
 
 class CorrelationMethod(Enum):
     XCORR = 1

--- a/src/noisepy/seis/zarrstore.py
+++ b/src/noisepy/seis/zarrstore.py
@@ -6,7 +6,7 @@ import zarr
 from datetimerange import DateTimeRange
 
 from noisepy.seis.constants import DONE_PATH
-from noisepy.seis.utils import remove_nan_rows, unstack
+from noisepy.seis.utils import TimeLogger, remove_nan_rows, unstack
 
 from .datatypes import Channel, ChannelType, CrossCorrelation, Station
 from .stores import (
@@ -122,7 +122,9 @@ class ZarrCCStore(CrossCorrelationDataStore):
         ]
         all_ccs = np.stack(padded, axis=0)
         json_params = [(p.src.name, p.src.location, p.rec.name, p.rec.location, p.parameters) for p in ccs]
+        tlog = TimeLogger(logger, logging.DEBUG)
         self.helper.append(path, {CHANNELS_ATTR: json_params, VERSION_ATTR: 1.0}, all_ccs)
+        tlog.log(f"writing {len(ccs)} CCs to {path}")
 
     def is_done(self, timespan: DateTimeRange):
         return self.helper.is_done(timespan_str(timespan))


### PR DESCRIPTION
There was a bug in the use of `Station` objects as a dictionary key. The class was overriding `__hash__` but not `__eq__`, which resulted in erratic behavior when used as a key.

+ additional logging