### PR TITLE
Limit to Python >=3.10 and pin dependencies

### DIFF
--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4.5.0
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install pre-commit
       run: pip install pre-commit==3.3.3
     - name: Run pre-commit checks

--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4.5.0
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install pre-commit
       run: pip install pre-commit==3.3.3
     - name: Run pre-commit checks

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -118,7 +118,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python_version: ['3,9', '3.10']
+        python_version: ['3.9', '3.10']
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Repo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  python_version: '3.8'
+  python_version: '3.10'
   RDMAV_FORK_SAFE: 1
 jobs:
   unit_tests:
@@ -41,17 +41,15 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python_version: ['3.8', '3.10']
+        python_version: ['3.10']
         method: [linear,robust, nroot, selective, auto_covariance, pws]
         freq_norm: [rma]
         format: [asdf]
         include:
         - method: linear
-          python_version: '3.10'
           freq_norm: no
           format: zarr
         - method: robust
-          python_version: '3.9'
           freq_norm: phase_only
           format: zarr
     runs-on: ubuntu-22.04
@@ -118,7 +116,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python_version: ['3.8', '3.10']
+        python_version: ['3.10']
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Repo
@@ -138,7 +136,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python_version: ['3.8', '3.10']
+        python_version: ['3.10']
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Repo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python_version: ['3.10']
+        python_version: ['3.9', '3.10']
         method: [linear,robust, nroot, selective, auto_covariance, pws]
         freq_norm: [rma]
         format: [asdf]
@@ -51,7 +51,7 @@ jobs:
           freq_norm: no
           format: zarr
         - method: robust
-          python_version: '3.10'
+          python_version: '3.9'
           freq_norm: phase_only
           format: zarr
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -118,7 +118,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python_version: ['3.10']
+        python_version: ['3,9', '3.10']
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Repo
@@ -138,7 +138,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python_version: ['3.10']
+        python_version: ['3.9', '3.10']
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Repo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,9 +47,11 @@ jobs:
         format: [asdf]
         include:
         - method: linear
+          python_version: '3.10'
           freq_norm: no
           format: zarr
         - method: robust
+          python_version: '3.10'
           freq_norm: phase_only
           format: zarr
     runs-on: ubuntu-22.04

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,12 +42,10 @@
       "module": "noisepy.seis.main",
       "args": [
         "stack",
-        "--raw_data_path",
-        "${userHome}/test_temp/RAW_DATA",
         "--ccf_path",
         "${userHome}/test_temp/CCF",
         "--stack_path",
-        "/Users/carlosg/test_temp/STACK",
+        "${userHome}/test_temp/STACK",
         "--stack_method",
         "linear"
       ],
@@ -85,9 +83,9 @@
         "--raw_data_path",
         "${userHome}/s3tmp/scedc/2022/002",
         "--ccf_path",
-        "${userHome}/ccfs3tmp/",
+        "${userHome}/test_temp/CCF",
         "--stations",
-        "SBC,RIO,DEV,HEC,RLR,SVD,RPV,BAK",
+        "CBC,BAK",
         "--xml_path",
         "/Users/carlosg/s3tmp/FDSNstationXML"
       ],
@@ -114,7 +112,7 @@
         "--start",
         "2022-02-02",
         "--end",
-        "2022-02-05"
+        "2022-02-03"
       ],
       "console": "integratedTerminal",
       "justMyCode": true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ NoisePy is going under major re-development. Part of the core development involv
 
 Fork the repository, and create your local version, then follow the installation steps:
 ```bash
-conda create -n noisepy python=3.8 pip
+conda create -n noisepy python=3.10 pip
 conda activate noisepy
 conda install -c conda-forge openmpi
 python -m ipykernel install --user --name noisepy
@@ -45,6 +45,9 @@ tests/test_cli.sh asdf
 NOTE: The CLI tests download a small amount of data from SCEDC to test the download funcionality. Occassionally, the service
 is unavailable and the test will fail. This is usually resolved in a few minutes.
 
+## Pull Requests
+
+Please follow the [Conventional Commits](https://github.com/uw-ssec/rse-guidelines/blob/main/conventional-commits.md) naming for pull request titles.
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ The nature of NoisePy being composed of python scripts allows flexible package i
 
 ## With Conda and pip:
 ```bash
-conda create -n noisepy python=3.8 pip
+conda create -n noisepy python=3.10 pip
 conda activate noisepy
 pip install noisepy-seis
 ```
 
 ## With Conda and pip and MPI support:
 ```bash
-conda create -n noisepy python=3.8 pip
+conda create -n noisepy python=3.10 pip
 conda activate noisepy
 conda install -c conda-forge openmpi
 pip install noisepy-seis[mpi]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "A High-performance Computing Python Package for Ambient Noise Analysis"
 readme = "README.md"
 license = {file= "LICENSE"}
-requires-python = ">=3.8,<3.11"
+requires-python = ">=3.10,<3.11"
 authors = [
     { email = "mdenolle@uw.edu", name = "Marine Denolle" },
     { email = "chengxin_jiang@fas.harvard.edu", name = "Chengxin Jiang" },
@@ -30,24 +30,24 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-    "DateTimeRange==2.0.0,<3.0.0",
-    "numpy>=1.22.0,<2.0.0",
-    "h5py>=3.8.0,<4.0.0",
-    "numba>=0.57.0,<1.0.0",
-    "pandas>=1.5.3,<2.0.0",
-    "pyasdf>=0.7.5,<1.0.0",
-    "pycwt>=0.3.0a22,<1.0.0",
-    "diskcache>=5.6.1,<6.0",
-    "fsspec>=2023.4.0,<2024.0.0",
-    "s3fs>=2023.4.0,<2024.0.0",
+    "DateTimeRange==2.0.0",
+    "numpy==1.22.0",
+    "h5py==3.8.0",
+    "numba==0.57.0",
+    "pandas==1.5.3",
+    "pyasdf==0.7.5",
+    "pycwt==0.3.0a22",
+    "diskcache==5.6.1",
+    "fsspec==2023.4.0",
+    "s3fs==2023.4.0",
     "aiobotocore==2.5.2", # "2.5.3 is broken"
-    "pydantic>=2.0.0,<3.0.0",
-    "PyYAML>=6.0,<7.0",
-    "pydantic-yaml>=1.0,<2.0",
-    "zarr>=2.14.2,<3.0.0",
+    "pydantic==2.0.0",
+    "PyYAML==6.0",
+    "pydantic-yaml==1.0",
+    "zarr==2.14.2",
 ]
 
 
@@ -76,15 +76,15 @@ packages = ["src/noisepy"]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.2.2,<8.0.0",
-    "memory-profiler>=0.61,<1.0.0",
-    "pre-commit>=3.3.3,<4.0.0",
+    "pytest==7.2.2",
+    "memory-profiler==0.61",
+    "pre-commit==3.3.3",
 ]
 sql = [
     "SQLite3-0611",
 ]
 mpi = [
-    "mpi4py>=3.1.4,<4.0.0",
+    "mpi4py==3.1.4",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "A High-performance Computing Python Package for Ambient Noise Analysis"
 readme = "README.md"
 license = {file= "LICENSE"}
-requires-python = ">=3.10,<3.11"
+requires-python = ">=3.9,<3.11"
 authors = [
     { email = "mdenolle@uw.edu", name = "Marine Denolle" },
     { email = "chengxin_jiang@fas.harvard.edu", name = "Chengxin Jiang" },
@@ -33,21 +33,21 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-    "DateTimeRange==2.0.0",
-    "numpy==1.22.0",
-    "h5py==3.8.0",
-    "numba==0.57.0",
-    "pandas==1.5.3",
-    "pyasdf==0.7.5",
-    "pycwt==0.3.0a22",
-    "diskcache==5.6.1",
-    "fsspec==2023.4.0",
-    "s3fs==2023.4.0",
+    "DateTimeRange>=2.0.0,<3.0.0",
+    "numpy>=1.22.0, <2.0.0",
+    "h5py>=3.8.0,<4.0.0",
+    "pandas>=1.5.3,<2.0.0",
+    "numba>=0.57.0,<1.0.0",
+    "pyasdf>=0.7.5,<1.0.0",
+    "pycwt>=0.3.0a22,<1.0.0",
+    "diskcache>=5.6.1,<6.0.0",
+    "fsspec>=2023.4.0,<2024.0.0",
+    "s3fs==2023.4.0,<2024.0.0",
+    "zarr>=2.14.2,<3.0.0",
     "aiobotocore==2.5.2", # "2.5.3 is broken"
     "pydantic==2.0.0",
     "PyYAML==6.0",
     "pydantic-yaml==1.0",
-    "zarr==2.14.2",
 ]
 
 
@@ -84,7 +84,7 @@ sql = [
     "SQLite3-0611",
 ]
 mpi = [
-    "mpi4py==3.1.4",
+    "mpi4py>=3.1.4,<4.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Reducing the supported platforms and variability in dependencies to help provide a more consistent experience for noisepy users. 

