### PR TITLE
Fixes/refactoring from large scale tests on AWS/S3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "diskcache>=5.6.1,<6.0.0",
     "fsspec>=2023.4.0,<2024.0.0",
     "s3fs==2023.4.0,<2024.0.0",
-    "zarr>=2.14.2,<3.0.0",
+    "zarr==2.14.2",
     "aiobotocore==2.5.2", # "2.5.3 is broken"
     "pydantic==2.0.0",
     "PyYAML==6.0",

--- a/src/noisepy/seis/S2_stacking.py
+++ b/src/noisepy/seis/S2_stacking.py
@@ -12,7 +12,7 @@ from datetimerange import DateTimeRange
 from noisepy.seis.datatypes import ConfigParameters, StackMethod, Station
 from noisepy.seis.scheduler import Scheduler, SingleNodeScheduler
 from noisepy.seis.stores import CrossCorrelationDataStore, StackStore
-from noisepy.seis.utils import TimeLogger, _get_results
+from noisepy.seis.utils import TimeLogger, get_results
 
 from . import noise_module
 
@@ -71,7 +71,7 @@ def stack(
     pairs_node = [pairs_all[i] for i in scheduler.get_indices(pairs_all)]
 
     tasks = [executor.submit(stack_pair, p[0], p[1], timespans, cc_store, stack_store, fft_params) for p in pairs_node]
-    _ = _get_results(tasks, "Stacking Pairs")
+    _ = get_results(tasks, "Stacking Pairs")
     scheduler.synchronize()
     tlog.log("step 2 in total", t_tot)
 

--- a/src/noisepy/seis/channelcatalog.py
+++ b/src/noisepy/seis/channelcatalog.py
@@ -84,6 +84,7 @@ class XMLStationChannelCatalog(ChannelCatalog):
             logger.warning(f"Could not find StationXML file {xmlfile}. Returning empty Inventory()")
             return obspy.Inventory()
         with self.fs.open(xmlfile) as f:
+            logger.info(f"Reading StationXML file {xmlfile}")
             return read_inventory(f)
 
 

--- a/src/noisepy/seis/datatypes.py
+++ b/src/noisepy/seis/datatypes.py
@@ -296,5 +296,7 @@ class CrossCorrelation:
 def _to_json_type(value: Any) -> Any:
     # special case since numpy arrays are not json serializable
     if type(value) == np.ndarray:
-        return value.tolist()
+        return list(map(_to_json_type, value))
+    elif type(value) == np.float64 or type(value) == np.float32:
+        return float(value)
     return value

--- a/src/noisepy/seis/datatypes.py
+++ b/src/noisepy/seis/datatypes.py
@@ -290,7 +290,11 @@ class CrossCorrelation:
         self.src = src
         self.rec = rec
         self.data = data
-        self.parameters = {k: _to_json_type(v) for k, v in params.items()}
+        self.parameters = to_json_types(params)
+
+
+def to_json_types(params: Dict[str, Any]) -> Dict[str, Any]:
+    return {k: _to_json_type(v) for k, v in params.items()}
 
 
 def _to_json_type(value: Any) -> Any:
@@ -299,4 +303,6 @@ def _to_json_type(value: Any) -> Any:
         return list(map(_to_json_type, value))
     elif type(value) == np.float64 or type(value) == np.float32:
         return float(value)
+    elif type(value) == np.int64 or type(value) == np.int32:
+        return int(value)
     return value

--- a/src/noisepy/seis/hierarchicalstores.py
+++ b/src/noisepy/seis/hierarchicalstores.py
@@ -1,0 +1,195 @@
+import logging
+import threading
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+from datetimerange import DateTimeRange
+
+from noisepy.seis.datatypes import ChannelType, CrossCorrelation, Station
+from noisepy.seis.stores import CrossCorrelationDataStore, timespan_str
+from noisepy.seis.utils import TimeLogger, remove_nan_rows, unstack
+
+CHANNELS_ATTR = "channels"
+VERSION_ATTR = "version"
+
+logger = logging.getLogger(__name__)
+
+
+class ArrayStore(ABC):
+    """
+    An interface definition for reading and writing arrays with metadata
+    """
+
+    @abstractmethod
+    def append(self, path: str, params: Dict[str, Any], data: np.ndarray):
+        pass
+
+    @abstractmethod
+    def load_paths(self) -> List[str]:
+        pass
+
+    @abstractmethod
+    def read(self, path: str) -> Optional[Tuple[np.ndarray, Dict[str, Any]]]:
+        pass
+
+
+class HierarchicalCCStoreBase(CrossCorrelationDataStore):
+    """
+    CrossCorrelationDataStore that uses hierarchical files for storage. The directory organization is as follows:
+    /                           (root)
+        station_pair
+            timestamp
+
+        The 'timestamp' files contain the cross-correlation data for all channels. The channel information is stored
+        as part of the array metadata.
+    """
+
+    def __init__(self, helper: ArrayStore) -> None:
+        super().__init__()
+        self.helper = helper
+        self._lock = threading.Lock()
+        tlog = TimeLogger(logger, logging.INFO)
+        self.path_cache = set(helper.load_paths())
+        tlog.log(f"keys_cache initialized with {len(self.path_cache)} keys")
+
+    def __getstate__(self) -> object:
+        state = self.__dict__.copy()
+        del state["_lock"]
+        return state
+
+    def __setstate__(self, state: object) -> None:
+        self.__dict__.update(state)
+        self._lock = threading.Lock()
+
+    def contains(self, timespan: DateTimeRange, src: Station, rec: Station) -> bool:
+        path = self._get_path(timespan, src, rec)
+        with self._lock:
+            # The keys have the full path to the files so we do a prefix check
+            # since the path is just the directory name
+            return any(map(lambda k: path in k, self.path_cache))
+
+    def append(
+        self,
+        timespan: DateTimeRange,
+        src: Station,
+        rec: Station,
+        ccs: List[CrossCorrelation],
+    ):
+        path = self._get_path(timespan, src, rec)
+        # Some channels may have different lengths, so pad them with NaNs for stacking
+        max_rows = max(d.data.shape[0] for d in ccs)
+        max_cols = max(d.data.shape[1] for d in ccs)
+        padded = [
+            np.pad(
+                d.data,
+                ((0, max_rows - d.data.shape[0]), (0, max_cols - d.data.shape[1])),
+                mode="constant",
+                constant_values=np.nan,
+            )
+            for d in ccs
+        ]
+        all_ccs = np.stack(padded, axis=0)
+        json_params = [(p.src.name, p.src.location, p.rec.name, p.rec.location, p.parameters) for p in ccs]
+        tlog = TimeLogger(logger, logging.DEBUG)
+        self.helper.append(path, {CHANNELS_ATTR: json_params, VERSION_ATTR: 1.0}, all_ccs)
+        tlog.log(f"writing {len(ccs)} CCs to {path}")
+
+        with self._lock:
+            self.path_cache.add(path)
+
+    @abstractmethod
+    def get_timespans(self) -> List[DateTimeRange]:
+        pass
+
+    @abstractmethod
+    def get_station_pairs(self) -> List[Tuple[Station, Station]]:
+        pass
+
+    def read_correlations(self, timespan: DateTimeRange, src_sta: Station, rec_sta: Station) -> List[CrossCorrelation]:
+        path = self._get_path(timespan, src_sta, rec_sta)
+
+        tuple = self.helper.read(path)
+        if not tuple:
+            return []
+        array, metadata = tuple
+
+        channel_params = self._read_cc_metadata(metadata)
+        cc_stack = array[:]
+        ccs = unstack(cc_stack)
+
+        return [
+            CrossCorrelation(src, rec, params, remove_nan_rows(data))
+            for (src, rec, params), data in zip(channel_params, ccs)
+        ]
+
+    def _read_cc_metadata(self, metadata: Dict[str, Any]):
+        channels_dict = metadata[CHANNELS_ATTR]
+        channel_params = [
+            (ChannelType(src, src_loc), ChannelType(rec, rec_loc), params)
+            for src, src_loc, rec, rec_loc, params in channels_dict
+        ]
+
+        return channel_params
+
+    def _get_path(self, timespan: DateTimeRange, src_sta: Station, rec_sta: Station) -> str:
+        stations = self._get_station_pair(src_sta, rec_sta)
+        times = timespan_str(timespan)
+        return f"{stations}/{times}"
+
+
+class HierarchicalStackStoreBase:
+    """
+    A class for reading and writing stack data files. Hierarchy is:
+    /
+        station_pair            (group)
+            stack name          (group)
+                component       (array)
+    """
+
+    def __init__(self, store: ArrayStore) -> None:
+        super().__init__()
+        self.helper = store
+
+    def mark_done(self, src: Station, rec: Station):
+        path = self._get_station_path(src, rec)
+        return self.helper.mark_done(path)
+
+    def is_done(self, src: Station, rec: Station):
+        path = self._get_station_path(src, rec)
+        return self.helper.is_done(path)
+
+    def append(
+        self, src: Station, rec: Station, component: str, name: str, stack_params: Dict[str, Any], data: np.ndarray
+    ):
+        path = self._get_path(src, rec, component, name)
+        self.helper.append(path, stack_params, data)
+
+    def get_station_pairs(self) -> List[Tuple[Station, Station]]:
+        return self.helper.get_station_pairs()
+
+    def get_stack_names(self, src: Station, rec: Station) -> List[str]:
+        path = self._get_station_path(src, rec)
+        return self._get_children(path)
+
+    def get_components(self, src: Station, rec: Station, name: str) -> List[str]:
+        path = self._get_station_path(src, rec) + "/" + name
+        return self._get_children(path)
+
+    def read(self, src: Station, rec: Station, component: str, name: str) -> Tuple[Dict[str, Any], np.ndarray]:
+        path = self._get_path(src, rec, component, name)
+        tuple = self.helper.read(path)
+        if not tuple:
+            return {}, np.zeros((0,))
+        return tuple[1], tuple[0]
+
+    def _get_children(self, path: str) -> List[str]:
+        if path not in self.helper.root:
+            return []
+        return list(self.helper.root[path].array_keys()) + list(self.helper.root[path].group_keys())
+
+    def _get_station_path(self, src: Station, rec: Station) -> str:
+        return f"{src}_{rec}"
+
+    def _get_path(self, src: Station, rec: Station, component: str, name: str) -> str:
+        return f"{self._get_station_path(src,rec)}/{name}/{component}"

--- a/src/noisepy/seis/main.py
+++ b/src/noisepy/seis/main.py
@@ -194,7 +194,7 @@ def main(args: typing.Any):
         fh = logging.FileHandler(
             args.logfile,
         )
-        fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(module)s.%(funcName)s(): %(message)s"))
+        fh.setFormatter(logging.Formatter("%(asctime)s\t%(levelname)s\t%(module)s.%(funcName)s():\t%(message)s"))
         logging.getLogger("").addHandler(fh)
 
     logger.info(f"NoisePy version: {__version__}")
@@ -309,8 +309,16 @@ def add_mpi(parser: Any):
 
 
 def main_cli():
-    args = parse_args(sys.argv[1:])
-    main(args)
+    try:
+        args = parse_args(sys.argv[1:])
+        main(args)
+    except Exception as e:
+        logger.exception(e)
+        raise e
+    finally:
+        logging.shutdown()
+        sys.stdout.flush()
+        sys.stderr.flush()
 
 
 def parse_args(arguments: Iterable[str]) -> argparse.Namespace:
@@ -337,14 +345,4 @@ def _enable_s3fs_debug_logs():
 
 
 if __name__ == "__main__":
-    try:
-        main_cli()
-    except Exception as e:
-        print(f"An error occcurred: {e}")
-        logger.exception(e)
-        raise e
-    finally:
-        print("Shutting down logging")
-        logging.shutdown()
-        sys.stdout.flush()
-        sys.stderr.flush()
+    main_cli()

--- a/src/noisepy/seis/main.py
+++ b/src/noisepy/seis/main.py
@@ -227,7 +227,7 @@ def main(args: typing.Any):
                 args.stack_path, mode="a", storage_options=params.get_storage_options(args.stack_path)
             )
         else:
-            ASDFStackStore(args.stack_path, "a")
+            return ASDFStackStore(args.stack_path, "a")
 
     def run_cross_correlation():
         try:

--- a/src/noisepy/seis/numpystore.py
+++ b/src/noisepy/seis/numpystore.py
@@ -1,0 +1,112 @@
+import io
+import json
+import logging
+import tarfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+from datetimerange import DateTimeRange
+
+from noisepy.seis.constants import DONE_PATH
+from noisepy.seis.datatypes import Station
+from noisepy.seis.hierarchicalstores import (
+    ArrayStore,
+    HierarchicalCCStoreBase,
+    HierarchicalStackStoreBase,
+)
+from noisepy.seis.stores import parse_station_pair, parse_timespan
+from noisepy.seis.utils import fs_join, get_filesystem
+
+logger = logging.getLogger(__name__)
+
+TAR_GZ_EXTENSION = ".tar.gz"
+FILE_ARRAY_NPY = "array.npy"
+FILE_PARAMS_JSON = "params.json"
+
+
+class NumpyArrayStore(ArrayStore):
+    def __init__(self, root_dir: str, mode: str, storage_options={}) -> None:
+        super().__init__()
+        logger.info(f"store creating at {root_dir}, mode={mode}, storage_options={storage_options}")
+        storage_options["client_kwargs"] = {"region_name": "us-west-2"}
+        self.root_path = root_dir
+        self.storage_options = storage_options
+        self.fs = get_filesystem(root_dir, storage_options=storage_options)
+        logger.info(f"Numpy store created at {root_dir}")
+
+    def load_paths(self) -> List[str]:
+        return self.fs.find(self.root_path)
+
+    def append(self, path: str, params: Dict[str, Any], data: np.ndarray):
+        logger.debug(f"Appending to {path}: {data.shape}")
+
+        js = json.dumps(params)
+
+        def add_file_bytes(tar, name, f):
+            f.seek(0)
+            ti = tarfile.TarInfo(name=name)
+            ti.size = f.getbuffer().nbytes
+            tar.addfile(ti, fileobj=f)
+
+        self.fs.makedirs(fs_join(self.root_path, path), exist_ok=True)
+        with self.fs.open(fs_join(self.root_path, path + TAR_GZ_EXTENSION), "wb") as f:
+            with tarfile.open(fileobj=f, mode="w:gz") as tar:
+                with io.BytesIO() as npyf:
+                    np.save(npyf, data, allow_pickle=False)
+                    with io.BytesIO() as jsf:
+                        jsf.write(js.encode("utf-8"))
+
+                        add_file_bytes(tar, FILE_ARRAY_NPY, npyf)
+                        add_file_bytes(tar, FILE_PARAMS_JSON, jsf)
+
+    def is_done(self, key: str):
+        if DONE_PATH not in self.root.array_keys():
+            return False
+        done_array = self.root[DONE_PATH]
+        return key in done_array.attrs.keys()
+
+    def mark_done(self, key: str):
+        done_array = self.root.require_dataset(DONE_PATH, shape=(1, 1))
+        done_array.attrs[key] = True
+
+    def read(self, path: str) -> Optional[Tuple[np.ndarray, Dict[str, Any]]]:
+        file = fs_join(self.root_path, path + TAR_GZ_EXTENSION)
+        if not self.fs.exists(file):
+            return None
+
+        with self.fs.open(file, "rb") as f:
+            with tarfile.open(fileobj=f, mode="r:gz") as tar:
+                npy_mem = tar.getmember(FILE_ARRAY_NPY)
+                with tar.extractfile(npy_mem) as f:
+                    array_file = io.BytesIO()
+                    array_file.write(f.read())
+                    array_file.seek(0)
+                    array = np.load(array_file, allow_pickle=False)
+                params_mem = tar.getmember(FILE_PARAMS_JSON)
+                with tar.extractfile(params_mem) as f:
+                    params = json.load(f)
+                return (array, params)
+
+
+class NumpyCCStore(HierarchicalCCStoreBase):
+    def __init__(self, root_dir: str, mode: str = "a", storage_options={}) -> None:
+        super().__init__(NumpyArrayStore(root_dir, mode, storage_options=storage_options))
+
+    def get_timespans(self) -> List[DateTimeRange]:
+        paths = list(filter(lambda x: x.endswith(TAR_GZ_EXTENSION), self.helper.load_paths()))
+        timespans = set(Path(p).name.removesuffix(TAR_GZ_EXTENSION) for p in paths)
+        timespans.discard(None)
+        return list(map(parse_timespan, sorted(timespans)))
+
+    def get_station_pairs(self) -> List[Tuple[Station, Station]]:
+        paths = self.helper.load_paths()
+        paths = set(Path(p).parts[-2] for p in paths)
+
+        pairs = [parse_station_pair(k) for k in paths]
+        return [p for p in pairs if p]
+
+
+class NumpyStackStore(HierarchicalStackStoreBase):
+    def __init__(self, root_dir: str, mode: str = "a", storage_options={}) -> None:
+        super().__init__(NumpyArrayStore(root_dir, mode, storage_options=storage_options))

--- a/src/noisepy/seis/numpystore.py
+++ b/src/noisepy/seis/numpystore.py
@@ -8,8 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 from datetimerange import DateTimeRange
 
-from noisepy.seis.constants import DONE_PATH
-from noisepy.seis.datatypes import Station
+from noisepy.seis.datatypes import Station, to_json_types
 from noisepy.seis.hierarchicalstores import (
     ArrayStore,
     HierarchicalCCStoreBase,
@@ -41,6 +40,7 @@ class NumpyArrayStore(ArrayStore):
     def append(self, path: str, params: Dict[str, Any], data: np.ndarray):
         logger.debug(f"Appending to {path}: {data.shape}")
 
+        params = to_json_types(params)
         js = json.dumps(params)
 
         def add_file_bytes(tar, name, f):
@@ -49,7 +49,8 @@ class NumpyArrayStore(ArrayStore):
             ti.size = f.getbuffer().nbytes
             tar.addfile(ti, fileobj=f)
 
-        self.fs.makedirs(fs_join(self.root_path, path), exist_ok=True)
+        dir = fs_join(self.root_path, str(Path(path).parent))
+        self.fs.makedirs(dir, exist_ok=True)
         with self.fs.open(fs_join(self.root_path, path + TAR_GZ_EXTENSION), "wb") as f:
             with tarfile.open(fileobj=f, mode="w:gz") as tar:
                 with io.BytesIO() as npyf:
@@ -61,14 +62,12 @@ class NumpyArrayStore(ArrayStore):
                         add_file_bytes(tar, FILE_PARAMS_JSON, jsf)
 
     def is_done(self, key: str):
-        if DONE_PATH not in self.root.array_keys():
-            return False
-        done_array = self.root[DONE_PATH]
-        return key in done_array.attrs.keys()
+        # TODO:
+        return False
 
     def mark_done(self, key: str):
-        done_array = self.root.require_dataset(DONE_PATH, shape=(1, 1))
-        done_array.attrs[key] = True
+        # TODO:
+        pass
 
     def read(self, path: str) -> Optional[Tuple[np.ndarray, Dict[str, Any]]]:
         file = fs_join(self.root_path, path + TAR_GZ_EXTENSION)

--- a/src/noisepy/seis/tiledb.py
+++ b/src/noisepy/seis/tiledb.py
@@ -1,0 +1,56 @@
+import json
+from typing import Any, Dict, List
+
+import numpy as np
+import tiledb
+
+from noisepy.seis.utils import fs_join, get_filesystem
+from noisepy.seis.zarrstore import logger
+
+
+# Experimentation with TileDB
+class _TileDBHelper:
+    def __init__(self, root_dir: str, mode: str, storage_options={}) -> None:
+        # if tiledb.default_ctx() is None:
+        logger.info(f"Creating TileDB at '{root_dir}' with {storage_options}")
+        cfg = tiledb.Ctx().config()
+        cfg.update({"py.init_buffer_bytes": 1024**2 * 50})
+        cfg.update({"vfs.s3.region": "us-west-2"})  # replace with bucket region
+        self.ctx = tiledb.default_ctx(cfg)
+        self.fs = get_filesystem(root_dir, storage_options=storage_options)
+        self.arr_path = fs_join(root_dir, "tile")
+        if self.fs.exists(self.arr_path):
+            logger.warning(f"Not creating {self.arr_path} because it already exists")
+            return
+
+        # Create the two dimensions: unit -> rows, time -> columns
+        pair_dim = tiledb.Dim(name="pair", domain=(0, 128000), tile=1000, dtype=np.int32)
+        stack_dim = tiledb.Dim(name="stack", domain=(0, 0), tile=1, dtype=np.int32)
+        chan_dim = tiledb.Dim(name="chan", domain=(0, 8), tile=9, dtype=np.int32)
+        time_dim = tiledb.Dim(name="time", domain=(0, 8000), tile=8001, dtype=np.int32)
+
+        # Create a domain using the two dimensions
+        dom1 = tiledb.Domain(pair_dim, stack_dim, chan_dim, time_dim)
+        attrib_cc = tiledb.Attr(name="cc", dtype=np.float32)
+        schema = tiledb.ArraySchema(domain=dom1, sparse=False, attrs=[attrib_cc])
+        tiledb.Array.create(self.arr_path, schema)
+
+    def contains(self, path: str) -> bool:
+        return False
+
+    def set_paths(self, paths: List[str]):
+        self.paths = {p: i for i, p in enumerate(paths)}
+
+    def append(
+        self,
+        path: str,
+        params: Dict[str, Any],
+        data: np.ndarray,
+    ):
+        index = self.paths[path]
+        logger.debug(f"Appending to {path}: {data.shape}, index = {index}")
+        if data.shape[0] < 9:
+            data = np.pad(data, ((0, 9 - data.shape[0]), (0, 0), (0, 0)), mode="constant", constant_values=np.nan)
+        with tiledb.open(self.arr_path, "w", ctx=self.ctx) as array:
+            array[index] = data
+            array.meta[path] = json.dumps(params)

--- a/src/noisepy/seis/utils.py
+++ b/src/noisepy/seis/utils.py
@@ -99,7 +99,7 @@ def error_if(condition: bool, msg: str, error_type: type = RuntimeError):
         raise error_type(msg)
 
 
-def _get_results(futures: Iterable[Future], task_name: str = "", logger: logging.Logger = None) -> Iterable[Future]:
+def get_results(futures: Iterable[Future], task_name: str = "", logger: logging.Logger = None) -> Iterable[Future]:
     # if running in AWS, use -1 for the position so it's logged properly
     position = -1 if AWS_EXECUTION_ENV in os.environ else None
 

--- a/src/noisepy/seis/zarrstore.py
+++ b/src/noisepy/seis/zarrstore.py
@@ -1,5 +1,4 @@
 import logging
-import threading
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -7,23 +6,19 @@ import zarr
 from datetimerange import DateTimeRange
 
 from noisepy.seis.constants import DONE_PATH
-from noisepy.seis.utils import TimeLogger, remove_nan_rows, unstack
-
-from .datatypes import Channel, ChannelType, CrossCorrelation, Station
-from .stores import (
-    CrossCorrelationDataStore,
-    parse_station_pair,
-    parse_timespan,
-    timespan_str,
+from noisepy.seis.datatypes import Station
+from noisepy.seis.hierarchicalstores import (
+    ArrayStore,
+    HierarchicalCCStoreBase,
+    HierarchicalStackStoreBase,
 )
 
-CHANNELS_ATTR = "channels"
-VERSION_ATTR = "version"
+from .stores import parse_station_pair, parse_timespan
 
 logger = logging.getLogger(__name__)
 
 
-class ZarrStoreHelper:
+class ZarrStoreHelper(ArrayStore):
     """
     Helper object for storing data and parameters into Zarr and track a "done" bit for subsets of the data
     'done' is a dummy array to track completed sets in its attribute dictionary.
@@ -40,34 +35,17 @@ class ZarrStoreHelper:
         logger.info(
             f"store creating at {root_dir}, mode={mode}, storage_options={storage_options}, cache_size={CACHE_SIZE}"
         )
+        # TODO:
+        storage_options["client_kwargs"] = {"region_name": "us-west-2"}
         store = zarr.storage.FSStore(root_dir, **storage_options)
         self.cache = zarr.LRUStoreCache(store, max_size=CACHE_SIZE)
         self.root = zarr.open_group(self.cache, mode=mode)
-        self._lock = threading.Lock()
-        self.keys_cache = set(self.cache.keys())
-        logger.info(f"store created at {root_dir}")
+        logger.info(f"store created at {root_dir}: {type(store)}. Zarr version {zarr.__version__}")
 
-    def __getstate__(self) -> object:
-        state = self.__dict__.copy()
-        del state["_lock"]
-        return state
+    def load_paths(self) -> List[str]:
+        return self.cache.keys()
 
-    def __setstate__(self, state: object) -> None:
-        self.__dict__.update(state)
-        self._lock = threading.Lock()
-
-    def contains(self, path: str) -> bool:
-        with self._lock:
-            # The keys have the full path to the .zarray/.zattrs/.zgroup files so we do a prefix check
-            # since the path is just the directory name
-            return any(map(lambda k: k.startswith(path), self.keys_cache))
-
-    def append(
-        self,
-        path: str,
-        params: Dict[str, Any],
-        data: np.ndarray,
-    ):
+    def append(self, path: str, params: Dict[str, Any], data: np.ndarray):
         logger.debug(f"Appending to {path}: {data.shape}")
         array = self.root.create_dataset(
             path,
@@ -76,8 +54,6 @@ class ZarrStoreHelper:
             dtype=data.dtype,
         )
         array.attrs.update(params)
-        with self._lock:
-            self.keys_cache.add(path)
 
     def is_done(self, key: str):
         if DONE_PATH not in self.root.array_keys():
@@ -93,57 +69,19 @@ class ZarrStoreHelper:
         pairs = [parse_station_pair(k) for k in self.root.group_keys() if k != DONE_PATH]
         return pairs
 
-    def read(self, path: str) -> Optional[zarr.Array]:
+    def read(self, path: str) -> Optional[Tuple[np.ndarray, Dict[str, Any]]]:
         if path not in self.root:
             return None
         array = self.root[path]
-        return array
+        metadata = {}
+        metadata.update(array.attrs)
+        return (array[:], metadata)
 
 
-class ZarrCCStore(CrossCorrelationDataStore):
-    """
-    CrossCorrelationDataStore that uses hierarchical Zarr files for storage. The directory organization is as follows:
-    /                           (root)
-        station_pair            (group)
-            timestamp           (array)
-
-        The 'timestamp' arrays contain the cross-correlation data for all channels. The channel information is stored
-        as part of the array attributes.
-    """
-
+class ZarrCCStore(HierarchicalCCStoreBase):
     def __init__(self, root_dir: str, mode: str = "a", storage_options={}) -> None:
-        super().__init__()
-        self.helper = ZarrStoreHelper(root_dir, mode, storage_options=storage_options)
-
-    def contains(self, timespan: DateTimeRange, src: Station, rec: Station) -> bool:
-        path = self._get_station_path(timespan, src, rec)
-        return self.helper.contains(path)
-
-    def append(
-        self,
-        timespan: DateTimeRange,
-        src: Station,
-        rec: Station,
-        ccs: List[CrossCorrelation],
-    ):
-        path = self._get_station_path(timespan, src, rec)
-        # Some channels may have different lengths, so pad them with NaNs for stacking
-        max_rows = max(d.data.shape[0] for d in ccs)
-        max_cols = max(d.data.shape[1] for d in ccs)
-        padded = [
-            np.pad(
-                d.data,
-                ((0, max_rows - d.data.shape[0]), (0, max_cols - d.data.shape[1])),
-                mode="constant",
-                constant_values=np.nan,
-            )
-            for d in ccs
-        ]
-        all_ccs = np.stack(padded, axis=0)
-        json_params = [(p.src.name, p.src.location, p.rec.name, p.rec.location, p.parameters) for p in ccs]
-        tlog = TimeLogger(logger, logging.DEBUG)
-        self.helper.append(path, {CHANNELS_ATTR: json_params, VERSION_ATTR: 1.0}, all_ccs)
-        tlog.log(f"writing {len(ccs)} CCs to {path}")
+        helper = ZarrStoreHelper(root_dir, mode, storage_options=storage_options)
+        super().__init__(helper)
 
     def get_timespans(self) -> List[DateTimeRange]:
         pairs = [k for k in self.helper.root.group_keys() if k != DONE_PATH]
@@ -155,94 +93,8 @@ class ZarrCCStore(CrossCorrelationDataStore):
     def get_station_pairs(self) -> List[Tuple[Station, Station]]:
         return self.helper.get_station_pairs()
 
-    def read_correlations(self, timespan: DateTimeRange, src_sta: Station, rec_sta: Station) -> List[CrossCorrelation]:
-        path = self._get_station_path(timespan, src_sta, rec_sta)
 
-        array = self.helper.read(path)
-        if not array:
-            return []
-
-        channel_params = self._read_cc_metadata(array)
-        cc_stack = array[:]
-        ccs = unstack(cc_stack)
-
-        return [
-            CrossCorrelation(src, rec, params, remove_nan_rows(data))
-            for (src, rec, params), data in zip(channel_params, ccs)
-        ]
-
-    def _read_cc_metadata(self, array):
-        channels_dict = array.attrs[CHANNELS_ATTR]
-        channel_params = [
-            (ChannelType(src, src_loc), ChannelType(rec, rec_loc), params)
-            for src, src_loc, rec, rec_loc, params in channels_dict
-        ]
-
-        return channel_params
-
-    def _get_station_path(self, timespan: DateTimeRange, src_sta: Station, rec_sta: Station) -> str:
-        stations = self._get_station_pair(src_sta, rec_sta)
-        times = timespan_str(timespan)
-        return f"{stations}/{times}"
-
-    def _get_path(self, timespan: DateTimeRange, src_chan: Channel, rec_chan: Channel) -> str:
-        channels = self._get_channel_pair(src_chan.type, rec_chan.type)
-        station_path = self._get_station_path(timespan, src_chan.station, rec_chan.station)
-        return f"{station_path}/{channels}"
-
-
-class ZarrStackStore:
-    """
-    A class for reading and writing stack data using Zarr format. Hierarchy is:
-    /
-        station_pair            (group)
-            stack name          (group)
-                component       (array)
-    """
-
+class ZarrStackStore(HierarchicalStackStoreBase):
     def __init__(self, root_dir: str, mode: str = "a", storage_options={}) -> None:
-        super().__init__()
-        self.helper = ZarrStoreHelper(root_dir, mode, storage_options=storage_options)
-
-    def mark_done(self, src: Station, rec: Station):
-        path = self._get_station_path(src, rec)
-        return self.helper.mark_done(path)
-
-    def is_done(self, src: Station, rec: Station):
-        path = self._get_station_path(src, rec)
-        return self.helper.is_done(path)
-
-    def append(
-        self, src: Station, rec: Station, component: str, name: str, stack_params: Dict[str, Any], data: np.ndarray
-    ):
-        path = self._get_path(src, rec, component, name)
-        self.helper.append(path, stack_params, data)
-
-    def get_station_pairs(self) -> List[Tuple[Station, Station]]:
-        return self.helper.get_station_pairs()
-
-    def get_stack_names(self, src: Station, rec: Station) -> List[str]:
-        path = self._get_station_path(src, rec)
-        return self._get_children(path)
-
-    def get_components(self, src: Station, rec: Station, name: str) -> List[str]:
-        path = self._get_station_path(src, rec) + "/" + name
-        return self._get_children(path)
-
-    def read(self, src: Station, rec: Station, component: str, name: str) -> Tuple[Dict[str, Any], np.ndarray]:
-        path = self._get_path(src, rec, component, name)
-        array = self.helper.read(path)
-        if not array:
-            return {}, np.zeros((0,))
-        return array.attrs, array[:]
-
-    def _get_children(self, path: str) -> List[str]:
-        if path not in self.helper.root:
-            return []
-        return list(self.helper.root[path].array_keys()) + list(self.helper.root[path].group_keys())
-
-    def _get_station_path(self, src: Station, rec: Station) -> str:
-        return f"{src}_{rec}"
-
-    def _get_path(self, src: Station, rec: Station, component: str, name: str) -> str:
-        return f"{self._get_station_path(src,rec)}/{name}/{component}"
+        helper = ZarrStoreHelper(root_dir, mode, storage_options=storage_options)
+        super().__init__(helper)

--- a/tests/test_ccstores.py
+++ b/tests/test_ccstores.py
@@ -7,6 +7,7 @@ from datetimerange import DateTimeRange
 
 from noisepy.seis.asdfstore import ASDFCCStore
 from noisepy.seis.datatypes import Channel, ChannelType, CrossCorrelation, Station
+from noisepy.seis.numpystore import NumpyCCStore
 from noisepy.seis.stores import CrossCorrelationDataStore
 from noisepy.seis.zarrstore import ZarrCCStore
 
@@ -21,6 +22,11 @@ def asdfstore(tmp_path: Path) -> ASDFCCStore:
 @pytest.fixture
 def zarrstore(tmp_path: Path) -> ZarrCCStore:
     return ZarrCCStore(str(tmp_path))
+
+
+@pytest.fixture
+def numpystore(tmp_path: Path) -> NumpyCCStore:
+    return NumpyCCStore(str(tmp_path))
 
 
 def _ccstore_test_helper(ccstore: CrossCorrelationDataStore):
@@ -71,3 +77,7 @@ def test_asdfccstore(asdfstore: ASDFCCStore):
 
 def test_zarrccstore(zarrstore: ZarrCCStore):
     _ccstore_test_helper(zarrstore)
+
+
+def test_numpyccstore(numpystore: NumpyCCStore):
+    _ccstore_test_helper(numpystore)


### PR DESCRIPTION
- Implementation of a numpy/tar.gz store
- Refactoring to share common code between Numpy and Zarr stores
- Parallelization of loading for SCEDC channel data
- Misc. fixes

[Test job on AWS](https://us-west-2.console.aws.amazon.com/batch/home?region=us-west-2#jobs/fargate/detail/c71b1f33-a75d-4303-8b1f-893fc6e2cf05)
[Output bucket](https://s3.console.aws.amazon.com/s3/buckets/carlosgjs-noisepy?region=us-west-2&prefix=test_batch/CCF_11_sta_2022_02_05_numpy/&showversions=false)


Reading results:
```
>>> from noisepy.seis.numpystore import NumpyCCStore
>>> s = NumpyCCStore("s3://carlosgjs-noisepy/test_batch/CCF_11_sta_2022_02_05_numpy/", mode="r")
2023-09-08 15:12:18,969 8336924160 INFO numpystore.__init__(): store creating at s3://carlosgjs-noisepy/test_batch/CCF_11_sta_2022_02_05_numpy/, mode=r, storage_options={}
2023-09-08 15:12:19,060 8336924160 INFO numpystore.__init__(): Numpy store created at s3://carlosgjs-noisepy/test_batch/CCF_11_sta_2022_02_05_numpy/
2023-09-08 15:12:19,085 10921996288 INFO credentials.load(): Found credentials in shared credentials file: ~/.aws/credentials
2023-09-08 15:12:19,252 8336924160 INFO utils.log_raw(): TIMING: 0.1922 secs. for keys_cache initialized with 57 keys
>>> p=s.get_station_pairs()
>>> ts= s.get_timespans()
>>> ts[0]
2022-02-05T00:00:00+0000 - 2022-02-06T00:00:00+0000
>>> p[0]
(CI.BAR, CI.BBR)
>>> cc =s.read_correlations(ts[0], p[0][0], p[0][1])[0]
>>> cc.data.shape
(1, 8001)
>>> cc.src,cc.rec
(BHE, BHE)
>>> cc.parameters
{'dt': 0.05, 'maxlag': 200, 'dist': 177.00657653808594, 'azi': 352.56695556640625, 'baz': 172.42984008789062, 'lonS': -116.67214965820312, 'latS': 32.680049896240234, 'lonR': -116.9207534790039, 'latR': 34.262298583984375, 'ngood': 188, 'cc_method': 'xcorr', 'time': 1644019200.0, 'substack': False, 'comp': 'EE'}
```
