### PR TITLE
Disable arm64 container build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,7 +128,7 @@ jobs:
         uses: docker/build-push-action@v4.1.1
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
   build-artifact:
     name: Build noisepy-seis package
     runs-on: ubuntu-20.04
-    if: false # github.repository == 'mdenolle/NoisePy'
+    if: github.repository == 'mdenolle/NoisePy'
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -104,7 +104,7 @@ jobs:
         password: ${{ secrets.PYPI_API_TOKEN }}
   push_to_registry:
     name: Push Docker image to Docker Hub
-    # needs: [publish-pypi, test-built-dist]
+    needs: [publish-pypi, test-built-dist]
     runs-on: ubuntu-latest
     steps:
       - name: Delay for PyPI
@@ -131,7 +131,5 @@ jobs:
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          push: true
-          # push: ${{ github.event_name != 'pull_request' }}
-          build-args: VERSION=0.9.73
-          #${{needs.test-built-dist.outputs.package-version}}
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: VERSION=${{needs.test-built-dist.outputs.package-version}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
   build-artifact:
     name: Build noisepy-seis package
     runs-on: ubuntu-20.04
-    if: github.repository == 'mdenolle/NoisePy'
+    if: false # github.repository == 'mdenolle/NoisePy'
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -104,7 +104,7 @@ jobs:
         password: ${{ secrets.PYPI_API_TOKEN }}
   push_to_registry:
     name: Push Docker image to Docker Hub
-    needs: [publish-pypi, test-built-dist]
+    # needs: [publish-pypi, test-built-dist]
     runs-on: ubuntu-latest
     steps:
       - name: Delay for PyPI
@@ -131,6 +131,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ github.event_name != 'pull_request' }}
+          # push: ${{ github.event_name != 'pull_request' }}
           build-args: VERSION=0.9.73
           #${{needs.test-built-dist.outputs.package-version}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,12 +125,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4.1.1
+        uses: docker/build-push-action@v4
         with:
           context: .
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          push: true
           # push: ${{ github.event_name != 'pull_request' }}
           build-args: VERSION=0.9.73
           #${{needs.test-built-dist.outputs.package-version}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,11 +125,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v4.1.1
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name != 'pull_request' }}
-          build-args: VERSION=${{needs.test-built-dist.outputs.package-version}}
+          build-args: VERSION=0.9.73
+          #${{needs.test-built-dist.outputs.package-version}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 ARG PYTHON_VERSION=3.10.12
-FROM --platform=$TARGETPLATFORM conda/miniconda3
+FROM --platform=$TARGETPLATFORM python:${PYTHON_VERSION}
+# FROM --platform=$TARGETPLATFORM continuumio/miniconda3
 
-RUN conda create -y --name noisepy python=${PYTHON_VERSION} numcodecs && conda init bash && source /root/.bashrc && conda activate noisepy
+# RUN conda create -y --name noisepy python=${PYTHON_VERSION} numcodecs && conda activate noisepy
+# RUN conda install -c conda-forge obspy
+# RUN conda init bash && . /root/.bashrc && conda activate noisepy
 
 ARG VERSION
 RUN pip3 install noisepy-seis==${VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,5 @@
-FROM --platform=$TARGETPLATFORM ubuntu:22.04
 ARG PYTHON_VERSION=3.10.12
-
-# Avoid timezone prompts during python installation
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update
-RUN apt-get install -y python3.10 && \
-    apt-get install -y python3-pip
+FROM --platform=$TARGETPLATFORM python:${PYTHON_VERSION}
 
 ARG VERSION
 RUN pip3 install noisepy-seis==${VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 ARG PYTHON_VERSION=3.10.12
-FROM --platform=$TARGETPLATFORM python:${PYTHON_VERSION}
+FROM --platform=$TARGETPLATFORM conda/miniconda3
+
+RUN conda create -y --name noisepy python=${PYTHON_VERSION} numcodecs && conda init bash && source /root/.bashrc && conda activate noisepy
 
 ARG VERSION
 RUN pip3 install noisepy-seis==${VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
+FROM --platform=$TARGETPLATFORM ubuntu:22.04
 ARG PYTHON_VERSION=3.10.12
-FROM --platform=$TARGETPLATFORM python:${PYTHON_VERSION}
-# FROM --platform=$TARGETPLATFORM continuumio/miniconda3
 
-# RUN conda create -y --name noisepy python=${PYTHON_VERSION} numcodecs && conda activate noisepy
-# RUN conda install -c conda-forge obspy
-# RUN conda init bash && . /root/.bashrc && conda activate noisepy
+# Avoid timezone prompts during python installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+RUN apt-get install -y python3.10 && \
+    apt-get install -y python3-pip
 
 ARG VERSION
 RUN pip3 install noisepy-seis==${VERSION}


### PR DESCRIPTION
There's a problem building the docker container on arm64. It fails to build the wheel for `numcodecs` with the errors:

```
gcc: error: unrecognized command-line option ‘-msse2’ 
gcc: error: unrecognized command-line option ‘-mavx2’
```

Disabling arm64 for now to unblock since all cloud use cases are based on amd64.
