### PR TITLE
Fix caching in XMLChannelCatalog

### DIFF
--- a/src/noisepy/seis/channelcatalog.py
+++ b/src/noisepy/seis/channelcatalog.py
@@ -78,7 +78,7 @@ class XMLStationChannelCatalog(ChannelCatalog):
         xmlfile = fs_join(self.xmlpath, file_name)
         return self._get_inventory_from_file(xmlfile)
 
-    @lru_cache
+    @lru_cache(maxsize=None)
     def _get_inventory_from_file(self, xmlfile):
         if not self.fs.exists(xmlfile):
             logger.warning(f"Could not find StationXML file {xmlfile}. Returning empty Inventory()")


### PR DESCRIPTION
Before (from Marine's run) ~10 mins:
```
2023-09-13 23:10:12,725 140060162046848 INFO utils.log_raw(): TIMING CC Main: 591.1919 secs. for get 756 channels
```
After (test run) ~2.8 mins:
```
2023-09-14 23:17:17,047 140072190446464 INFO utils.log_raw(): TIMING CC Main: 167.7949 secs. for get 753 channels
```