### PR TITLE
Fixes to SCEDC tutorial

### DIFF
--- a/src/noisepy/seis/asdfstore.py
+++ b/src/noisepy/seis/asdfstore.py
@@ -45,6 +45,9 @@ class ASDFDirectory(Generic[T]):
     def __init__(
         self, directory: str, mode: str, get_filename: Callable[[T], str], parse_filename: Callable[[str], T]
     ) -> None:
+        if mode not in ["a", "r"]:
+            raise ValueError(f"Invalid mode {mode}. Must be 'a' or 'r'")
+
         self.directory = directory
         self.mode = mode
         self.get_filename = get_filename
@@ -60,9 +63,11 @@ class ASDFDirectory(Generic[T]):
         return list(map(self.parse_filename, h5files))
 
     def contains(self, key: T, data_type: str, path: str = None):
-        with self[key] as ccf_ds:
-            if not ccf_ds:
-                return False
+        ccf_ds = self[key]
+
+        if not ccf_ds:
+            return False
+        with ccf_ds:
             # source-receiver pair
             exists = data_type in ccf_ds.auxiliary_data
             if path is not None and exists:

--- a/src/noisepy/seis/plotting_modules.py
+++ b/src/noisepy/seis/plotting_modules.py
@@ -655,7 +655,7 @@ def plot_all_moveout(
 
     USAGE:
     ----------------------
-    plot_substack_moveout('temp.h5','Allstack_pws',0.1,0.2,1,'ZZ',200,True,'./temp')
+    plot_substack_moveout(store,'Allstack_pws',0.1,0.2,1,'ZZ',200,True,'./temp')
     """
     # open data for read
     if savefig:
@@ -668,7 +668,9 @@ def plot_all_moveout(
         return
 
     # Read some common arguments from the first available data set:
-    params, dtmp = store.read(sta_pairs[0][0], sta_pairs[0][1], ccomp, stack_name)
+    stacks = store.read_stacks(sta_pairs[0][0], sta_pairs[0][1])
+    dtmp = stacks[0].data
+    params = stacks[0].parameters
     if len(params) == 0 or dtmp.size == 0:
         logger.error(f"No data available for plotting {stack_name}/{ccomp}")
         return
@@ -694,10 +696,12 @@ def plot_all_moveout(
 
     # load cc and parameter matrix
     for ii, (src, rec) in enumerate(sta_pairs):
-        params, all_data = store.read(src, rec, ccomp, stack_name)
-        if len(params) == 0 or all_data.size == 0:
+        stacks = store.read_stacks(src, rec)
+        stacks = list(filter(lambda x: x.name == stack_name and x.component == ccomp, stacks))
+        if len(stacks) == 0:
             logger.warning(f"No data available for {src}_{rec}/{stack_name}/{ccomp}")
             continue
+        params, all_data = stacks[0].parameters, stacks[0].data
         dist[ii] = params["dist"]
         ngood[ii] = params["ngood"]
         crap = bandpass(all_data, freqmin, freqmax, int(1 / dt), corners=4, zerophase=True)

--- a/tutorials/noisepy_scedc_tutorial.ipynb
+++ b/tutorials/noisepy_scedc_tutorial.ipynb
@@ -41,10 +41,8 @@
       ]
     },
     {
-      "cell_type": "code",
-      "execution_count": null,
+      "cell_type": "markdown",
       "metadata": {},
-      "outputs": [],
       "source": []
     },
     {
@@ -69,7 +67,7 @@
         "from noisepy.seis import cross_correlate, stack, plotting_modules, __version__       # noisepy core functions\n",
         "from noisepy.seis.asdfstore import ASDFCCStore, ASDFStackStore          # Object to store ASDF data within noisepy\n",
         "from noisepy.seis.scedc_s3store import SCEDCS3DataStore, channel_filter # Object to query SCEDC data from on S3\n",
-        "from noisepy.seis.datatypes import ConfigParameters                     # Main configuration object\n",
+        "from noisepy.seis.datatypes import ConfigParameters, StackMethod        # Main configuration object\n",
         "from noisepy.seis.channelcatalog import XMLStationChannelCatalog        # Required stationXML handling object\n",
         "import os\n",
         "from datetime import datetime\n",
@@ -175,8 +173,8 @@
       "outputs": [],
       "source": [
         "\n",
-        "config.acorr_only = False  # only perform auto-correlation or not\n",
-        "config.xcorr_only = True  # only perform cross-correlation or not\n",
+        "config.acorr_only = False # only perform auto-correlation or not\n",
+        "config.xcorr_only = True # only perform cross-correlation or not\n",
         "\n",
         "config.inc_hours = 24 # INC_HOURS is used in hours (integer) as the \n",
         "        #chunk of time that the paralelliztion will work.\n",
@@ -275,7 +273,7 @@
         "# stations = \"DGR,DEV,DLA,DNR,FMP,HLL,LGU,LLS,MLS,PDU,PDR,RIN,RIO,RVR,SMS,BBR,CHN,MWC,RIO,BBS,RPV,ADO,DEV\".split(\",\") # filter to these stations\n",
         "catalog = XMLStationChannelCatalog(S3_STATION_XML, storage_options=S3_STORAGE_OPTIONS) # Station catalog\n",
         "raw_store = SCEDCS3DataStore(S3_DATA, catalog, channel_filter(stations, \"BH\"), timerange, storage_options=S3_STORAGE_OPTIONS) # Store for reading raw data from S3 bucket\n",
-        "cc_store = ASDFCCStore(cc_data_path,mode=\"w\") # Store for writing CC data"
+        "cc_store = ASDFCCStore(cc_data_path) # Store for writing CC data"
       ]
     },
     {
@@ -385,7 +383,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "config.stack_method = \"linear\""
+        "config.stack_method = StackMethod.LINEAR"
       ]
     },
     {
@@ -394,7 +392,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "method_list = [method for method in dir(cc_store) if method.startswith('__') is False]\n",
+        "method_list = [method for method in dir(StackMethod) if not method.startswith(\"__\")]\n",
         "print(method_list)\n"
       ]
     },
@@ -445,6 +443,13 @@
       "source": [
         "plot_all_moveout(stack_store, 'Allstack_linear', 0.1, 0.2, 'ZZ', 1)"
       ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": []
     }
   ],
   "metadata": {


### PR DESCRIPTION
- Revert opening the cc_store in `"w"` mode and validate that only `"a"` or `"r"` are used
- Use StackMethod enum instead of string value
- Update `plot_all_moveout` to use new stack store interface