### PR TITLE
Fix source dist testing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,7 +82,7 @@ jobs:
         echo "=== Testing source tar file ==="
         # Install tar gz and check import
         python -m pip uninstall --yes noisepy-seis
-        python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade --pre --no-binary=:all: noisepy-seis==$latest_version
+        python -m pip install --extra-index-url https://test.pypi.org/simple --upgrade --pre --no-binary=noisepy-seis noisepy-seis==$latest_version
         python -c "import noisepy.seis; print(noisepy.seis.__version__)"
         noisepy --help
         echo "=== Done testing source tar file ==="

--- a/script/gen_req.py
+++ b/script/gen_req.py
@@ -4,8 +4,9 @@ import sys
 
 import pkginfo
 
+aws_suffix = "; extra == 'aws'"
 wheel = sys.argv[1]
 reqs = pkginfo.get_metadata(wheel).requires_dist
-core_reqs = [req for req in reqs if "extra" not in req]
+core_reqs = [req.removesuffix(aws_suffix) for req in reqs if "extra" not in req or aws_suffix in req]
 for req in core_reqs:
     print(req)


### PR DESCRIPTION
When testing the source distribution install, only install noisepy from source. Installing **all** from source it's unnecessary and more unstable. E.g. recently `hatchling==1.18.0` was failing to install from source.

The change to `gen_req.py` is opportunistic since it was missed in the last AWS PR and is only used in dev testing.